### PR TITLE
S5/S11: Implement checkout/return and view checkouts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,3 @@ Cookie-based sessions stored in PostgreSQL with scrypt password hashing. Guard h
 - PRs reviewed before merging to `dev`
 - Merge to `main` at end of each sprint
 - 80% line coverage minimum
-
-## Current Sprint (Iteration 2)
-
-Stories: U8, U26, U7, S11, U31, S5, S2, S15, U9, U12

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "dotenv": "^17.2.4",
         "lucide-react": "^0.563.0",
         "next": "16.1.6",
@@ -5578,6 +5579,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/co": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "lint": "eslint",
     "test": "jest",
     "test:watch": "jest --watch",
-    "migrate": "ts-node --compiler-options '{\"module\":\"commonjs\"}' src/lib/migrate.ts"
+    "migrate": "ts-node --project tsconfig.migrate.json src/lib/migrate.ts"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "dotenv": "^17.2.4",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",

--- a/src/__tests__/api/staff/checkouts.test.ts
+++ b/src/__tests__/api/staff/checkouts.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @jest-environment node
+ */
+
+const mockGetCurrentUser = jest.fn();
+jest.mock("@/lib/auth", () => ({
+    getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+jest.mock("next/headers", () => ({
+    cookies: jest.fn(),
+}));
+
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({
+    query: (text: string, params?: unknown[]) => mockQuery(text, params),
+}));
+
+import { GET, POST } from "@/app/api/staff/checkouts/route";
+import { GET as GET_ONE, PUT } from "@/app/api/staff/checkouts/[id]/route";
+import { NextRequest } from "next/server";
+
+const staffUser = {
+    id: "staff-1",
+    email: "staff@example.com",
+    name: "Staff",
+    role: "staff",
+};
+
+const adminUser = {
+    id: "admin-1",
+    email: "admin@example.com",
+    name: "Admin",
+    role: "admin",
+};
+
+function makeRequest(
+    body?: Record<string, unknown>,
+    method = "POST"
+): NextRequest {
+    return new NextRequest("http://localhost:3000/api/staff/checkouts", {
+        method: body ? method : "GET",
+        headers: { "Content-Type": "application/json" },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+}
+
+function makeParams(id: string) {
+    return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue(staffUser);
+});
+
+// ─── GET /api/staff/checkouts ───────────────────────────────────────
+
+describe("GET /api/staff/checkouts", () => {
+    it("returns 401 when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        const res = await GET();
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when user role is user", async () => {
+        mockGetCurrentUser.mockResolvedValue({ ...staffUser, role: "user" });
+        const res = await GET();
+        expect(res.status).toBe(403);
+    });
+
+    it("returns all checkouts for staff", async () => {
+        const checkouts = [
+            { id: "c1", work_title: "Book A", user_name: "Alice" },
+            { id: "c2", work_title: "Book B", user_name: "Bob" },
+        ];
+        mockQuery.mockResolvedValue({ rows: checkouts });
+
+        const res = await GET();
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual(checkouts);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("SELECT"),
+            undefined
+        );
+    });
+
+    it("returns all checkouts for admin", async () => {
+        mockGetCurrentUser.mockResolvedValue(adminUser);
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        const res = await GET();
+        expect(res.status).toBe(200);
+    });
+});
+
+// ─── POST /api/staff/checkouts ──────────────────────────────────────
+
+describe("POST /api/staff/checkouts", () => {
+    it("returns 401 when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        const res = await POST(
+            makeRequest({ work_id: "w1", user_id: "u1", due_date: "2026-03-01" })
+        );
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 400 when required fields are missing", async () => {
+        const res = await POST(makeRequest({ work_id: "w1" }));
+        const body = await res.json();
+        expect(res.status).toBe(400);
+        expect(body.error).toContain("required");
+    });
+
+    it("returns 404 when work does not exist", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // work lookup
+
+        const res = await POST(
+            makeRequest({ work_id: "w1", user_id: "u1", due_date: "2026-03-01" })
+        );
+        const body = await res.json();
+        expect(res.status).toBe(404);
+        expect(body.error).toContain("Work not found");
+    });
+
+    it("returns 404 when user does not exist", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "w1" }] }); // work exists
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // user lookup
+
+        const res = await POST(
+            makeRequest({ work_id: "w1", user_id: "u1", due_date: "2026-03-01" })
+        );
+        const body = await res.json();
+        expect(res.status).toBe(404);
+        expect(body.error).toContain("User not found");
+    });
+
+    it("returns 409 when work is already checked out", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "w1" }] }); // work exists
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "u1" }] }); // user exists
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "c1" }] }); // active checkout
+
+        const res = await POST(
+            makeRequest({ work_id: "w1", user_id: "u1", due_date: "2026-03-01" })
+        );
+        const body = await res.json();
+        expect(res.status).toBe(409);
+        expect(body.error).toContain("already checked out");
+    });
+
+    it("creates a checkout successfully", async () => {
+        const newCheckout = {
+            id: "c1",
+            work_id: "w1",
+            user_id: "u1",
+            due_date: "2026-03-01",
+            returned_at: null,
+        };
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "w1" }] }); // work exists
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "u1" }] }); // user exists
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // no active checkout
+        mockQuery.mockResolvedValueOnce({ rows: [newCheckout] }); // insert
+
+        const res = await POST(
+            makeRequest({ work_id: "w1", user_id: "u1", due_date: "2026-03-01" })
+        );
+        const body = await res.json();
+
+        expect(res.status).toBe(201);
+        expect(body).toEqual(newCheckout);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("INSERT"),
+            ["w1", "u1", "2026-03-01"]
+        );
+    });
+});
+
+// ─── GET /api/staff/checkouts/[id] ─────────────────────────────────
+
+describe("GET /api/staff/checkouts/[id]", () => {
+    it("returns 401 when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        const req = new NextRequest(
+            "http://localhost:3000/api/staff/checkouts/c1",
+            { method: "GET" }
+        );
+        const res = await GET_ONE(req, makeParams("c1"));
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 404 when checkout not found", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+        const req = new NextRequest(
+            "http://localhost:3000/api/staff/checkouts/c999",
+            { method: "GET" }
+        );
+        const res = await GET_ONE(req, makeParams("c999"));
+        expect(res.status).toBe(404);
+    });
+
+    it("returns a single checkout", async () => {
+        const checkout = { id: "c1", work_title: "Book A", user_name: "Alice" };
+        mockQuery.mockResolvedValue({ rows: [checkout] });
+        const req = new NextRequest(
+            "http://localhost:3000/api/staff/checkouts/c1",
+            { method: "GET" }
+        );
+        const res = await GET_ONE(req, makeParams("c1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual(checkout);
+    });
+});
+
+// ─── PUT /api/staff/checkouts/[id] (return) ────────────────────────
+
+describe("PUT /api/staff/checkouts/[id]", () => {
+    it("returns 401 when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        const req = new NextRequest(
+            "http://localhost:3000/api/staff/checkouts/c1",
+            {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ action: "return" }),
+            }
+        );
+        const res = await PUT(req, makeParams("c1"));
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 400 for invalid action", async () => {
+        const req = new NextRequest(
+            "http://localhost:3000/api/staff/checkouts/c1",
+            {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ action: "invalid" }),
+            }
+        );
+        const res = await PUT(req, makeParams("c1"));
+        expect(res.status).toBe(400);
+    });
+
+    it("returns a book successfully", async () => {
+        const returned = {
+            id: "c1",
+            work_id: "w1",
+            user_id: "u1",
+            returned_at: "2026-02-17T00:00:00Z",
+        };
+        mockQuery.mockResolvedValue({ rows: [returned] });
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/staff/checkouts/c1",
+            {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ action: "return" }),
+            }
+        );
+        const res = await PUT(req, makeParams("c1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.returned_at).toBeTruthy();
+    });
+
+    it("returns 404 when checkout not found or already returned", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/staff/checkouts/c999",
+            {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ action: "return" }),
+            }
+        );
+        const res = await PUT(req, makeParams("c999"));
+        expect(res.status).toBe(404);
+    });
+});

--- a/src/app/api/staff/checkouts/[id]/route.ts
+++ b/src/app/api/staff/checkouts/[id]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "@/lib/db";
+import { requireStaff } from "@/lib/staff";
+
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const check = await requireStaff();
+    if (!check.authorized) return check.response;
+
+    const { id } = await params;
+
+    const result = await query(
+        `SELECT c.id, c.work_id, c.user_id, c.checked_out_at, c.due_date,
+                c.returned_at, c.created_at, c.updated_at,
+                w.title AS work_title,
+                u.name AS user_name, u.email AS user_email
+         FROM checkouts c
+         JOIN works w ON w.id = c.work_id
+         JOIN users u ON u.id = c.user_id
+         WHERE c.id = $1`,
+        [id]
+    );
+
+    if (result.rows.length === 0) {
+        return NextResponse.json({ error: "Checkout not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(result.rows[0]);
+}
+
+export async function PUT(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const check = await requireStaff();
+    if (!check.authorized) return check.response;
+
+    const { id } = await params;
+    const body = await request.json();
+    const { action } = body;
+
+    if (action === "return") {
+        const result = await query(
+            `UPDATE checkouts SET returned_at = NOW(), updated_at = NOW()
+             WHERE id = $1 AND returned_at IS NULL
+             RETURNING id, work_id, user_id, checked_out_at, due_date, returned_at,
+                       created_at, updated_at`,
+            [id]
+        );
+
+        if (result.rows.length === 0) {
+            return NextResponse.json(
+                { error: "Checkout not found or already returned" },
+                { status: 404 }
+            );
+        }
+
+        return NextResponse.json(result.rows[0]);
+    }
+
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+}

--- a/src/app/api/staff/checkouts/route.ts
+++ b/src/app/api/staff/checkouts/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "@/lib/db";
+import { requireStaff } from "@/lib/staff";
+
+export async function GET() {
+    const check = await requireStaff();
+    if (!check.authorized) return check.response;
+
+    const result = await query(
+        `SELECT c.id, c.work_id, c.user_id, c.checked_out_at, c.due_date,
+                c.returned_at, c.created_at, c.updated_at,
+                w.title AS work_title,
+                u.name AS user_name, u.email AS user_email
+         FROM checkouts c
+         JOIN works w ON w.id = c.work_id
+         JOIN users u ON u.id = c.user_id
+         ORDER BY c.created_at DESC`
+    );
+
+    return NextResponse.json(result.rows);
+}
+
+export async function POST(request: NextRequest) {
+    const check = await requireStaff();
+    if (!check.authorized) return check.response;
+
+    const body = await request.json();
+    const { work_id, user_id, due_date } = body;
+
+    if (!work_id || !user_id || !due_date) {
+        return NextResponse.json(
+            { error: "work_id, user_id, and due_date are required" },
+            { status: 400 }
+        );
+    }
+
+    // Check that the work exists
+    const workResult = await query("SELECT id FROM works WHERE id = $1", [work_id]);
+    if (workResult.rows.length === 0) {
+        return NextResponse.json({ error: "Work not found" }, { status: 404 });
+    }
+
+    // Check that the user exists
+    const userResult = await query("SELECT id FROM users WHERE id = $1", [user_id]);
+    if (userResult.rows.length === 0) {
+        return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Check that the work is not already checked out
+    const activeCheckout = await query(
+        "SELECT id FROM checkouts WHERE work_id = $1 AND returned_at IS NULL",
+        [work_id]
+    );
+    if (activeCheckout.rows.length > 0) {
+        return NextResponse.json(
+            { error: "This work is already checked out" },
+            { status: 409 }
+        );
+    }
+
+    const result = await query(
+        `INSERT INTO checkouts (work_id, user_id, due_date)
+         VALUES ($1, $2, $3)
+         RETURNING id, work_id, user_id, checked_out_at, due_date, returned_at,
+                   created_at, updated_at`,
+        [work_id, user_id, due_date]
+    );
+
+    return NextResponse.json(result.rows[0], { status: 201 });
+}

--- a/src/app/staff/checkout-form-dialog.tsx
+++ b/src/app/staff/checkout-form-dialog.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useState } from "react";
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
+
+interface Work {
+    id: string;
+    title: string;
+}
+
+interface User {
+    id: string;
+    name: string;
+    email: string;
+}
+
+interface CheckoutFormDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    availableWorks: Work[];
+    users: User[];
+    onCreated: () => void;
+}
+
+function defaultDueDate() {
+    const date = new Date();
+    date.setDate(date.getDate() + 30);
+    return date.toISOString().split("T")[0];
+}
+
+export function CheckoutFormDialog({
+    open,
+    onOpenChange,
+    availableWorks,
+    users,
+    onCreated,
+}: CheckoutFormDialogProps) {
+    const [workListOpen, setWorkListOpen] = useState(false);
+    const [userListOpen, setUserListOpen] = useState(false);
+    const [workSearch, setWorkSearch] = useState("");
+    const [userSearch, setUserSearch] = useState("");
+    const [formData, setFormData] = useState({
+        work_id: "",
+        user_id: "",
+        due_date: defaultDueDate(),
+    });
+    const [formError, setFormError] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+
+    function handleOpenChange(nextOpen: boolean) {
+        if (nextOpen) {
+            setFormData({ work_id: "", user_id: "", due_date: defaultDueDate() });
+            setFormError("");
+            setWorkListOpen(false);
+            setUserListOpen(false);
+            setWorkSearch("");
+            setUserSearch("");
+        }
+        onOpenChange(nextOpen);
+    }
+
+    async function handleCheckout(e: React.SyntheticEvent) {
+        e.preventDefault();
+        setSubmitting(true);
+        setFormError("");
+
+        try {
+            const res = await fetch("/api/staff/checkouts", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(formData),
+            });
+
+            if (!res.ok) {
+                const data = await res.json();
+                setFormError(data.error || "Failed to create checkout");
+                return;
+            }
+
+            onOpenChange(false);
+            onCreated();
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent
+                className="max-w-lg"
+                onOpenAutoFocus={(e) => {
+                    e.preventDefault();
+                    (e.currentTarget as HTMLElement).focus();
+                }}
+            >
+                <DialogHeader>
+                    <DialogTitle>Check Out Item</DialogTitle>
+                    <DialogDescription>
+                        Select a work and a user to create a checkout.
+                    </DialogDescription>
+                </DialogHeader>
+                <form onSubmit={handleCheckout} className="space-y-4">
+                    <div className="space-y-2">
+                        <span className="text-sm font-medium">Work</span>
+                        <Command className="rounded-md border" shouldFilter={workListOpen}>
+                            <CommandInput
+                                name="work-search"
+                                placeholder="Search works..."
+                                hideIcon={!workListOpen && !!formData.work_id}
+                                value={workListOpen ? workSearch : (availableWorks.find((w) => w.id === formData.work_id)?.title ?? "")}
+                                onValueChange={(v) => setWorkSearch(v)}
+                                onFocus={() => {
+                                    setWorkSearch("");
+                                    setWorkListOpen(true);
+                                }}
+                                onBlur={() => setTimeout(() => setWorkListOpen(false), 150)}
+                            />
+                            {workListOpen && (
+                                <CommandList>
+                                    <CommandEmpty>No works found.</CommandEmpty>
+                                    <CommandGroup>
+                                        {availableWorks.map((work) => (
+                                            <CommandItem
+                                                key={work.id}
+                                                value={work.title}
+                                                onSelect={() => {
+                                                    setFormData((prev) => ({
+                                                        ...prev,
+                                                        work_id: work.id,
+                                                    }));
+                                                    setWorkSearch("");
+                                                    setWorkListOpen(false);
+                                                }}
+                                            >
+                                                <Check
+                                                    className={cn(
+                                                        "mr-2 h-4 w-4",
+                                                        formData.work_id === work.id
+                                                            ? "opacity-100"
+                                                            : "opacity-0",
+                                                    )}
+                                                />
+                                                {work.title}
+                                            </CommandItem>
+                                        ))}
+                                    </CommandGroup>
+                                </CommandList>
+                            )}
+                        </Command>
+                    </div>
+                    <div className="space-y-2">
+                        <span className="text-sm font-medium">Borrower</span>
+                        <Command className="rounded-md border" shouldFilter={userListOpen}>
+                            <CommandInput
+                                name="borrower-search"
+                                placeholder="Search by name or email..."
+                                hideIcon={!userListOpen && !!formData.user_id}
+                                value={userListOpen ? userSearch : (() => {
+                                    const u = users.find((u) => u.id === formData.user_id);
+                                    return u ? `${u.name} (${u.email})` : "";
+                                })()}
+                                onValueChange={(v) => setUserSearch(v)}
+                                onFocus={() => {
+                                    setUserSearch("");
+                                    setUserListOpen(true);
+                                }}
+                                onBlur={() => setTimeout(() => setUserListOpen(false), 150)}
+                            />
+                            {userListOpen && (
+                                <CommandList>
+                                    <CommandEmpty>No users found.</CommandEmpty>
+                                    <CommandGroup>
+                                        {users.map((user) => (
+                                            <CommandItem
+                                                key={user.id}
+                                                value={`${user.name} ${user.email}`}
+                                                onSelect={() => {
+                                                    setFormData((prev) => ({
+                                                        ...prev,
+                                                        user_id: user.id,
+                                                    }));
+                                                    setUserSearch("");
+                                                    setUserListOpen(false);
+                                                }}
+                                            >
+                                                <Check
+                                                    className={cn(
+                                                        "mr-2 h-4 w-4",
+                                                        formData.user_id === user.id
+                                                            ? "opacity-100"
+                                                            : "opacity-0",
+                                                    )}
+                                                />
+                                                {user.name} ({user.email})
+                                            </CommandItem>
+                                        ))}
+                                    </CommandGroup>
+                                </CommandList>
+                            )}
+                        </Command>
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="due_date">
+                            Due Date{" "}
+                            <span className="text-muted-foreground font-normal">(30 days by default)</span>
+                        </Label>
+                        <Input
+                            id="due_date"
+                            type="date"
+                            required
+                            value={formData.due_date}
+                            onChange={(e) =>
+                                setFormData((prev) => ({
+                                    ...prev,
+                                    due_date: e.target.value,
+                                }))
+                            }
+                        />
+                    </div>
+                    {formError && (
+                        <p className="text-sm text-destructive">{formError}</p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="submit"
+                            disabled={submitting || !formData.work_id || !formData.user_id}
+                        >
+                            {submitting ? "Checking out..." : "Check Out"}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/app/staff/delete-work-dialog.tsx
+++ b/src/app/staff/delete-work-dialog.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+
+interface Work {
+    id: string;
+    title: string;
+}
+
+interface DeleteWorkDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    work: Work | null;
+    onDeleted: (id: string) => void;
+}
+
+export function DeleteWorkDialog({ open, onOpenChange, work, onDeleted }: DeleteWorkDialogProps) {
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState("");
+
+    async function handleDelete() {
+        if (!work) return;
+        setSubmitting(true);
+        setError("");
+
+        try {
+            const res = await fetch(`/api/staff/works/${work.id}`, {
+                method: "DELETE",
+            });
+
+            if (!res.ok) {
+                const data = await res.json();
+                setError(data.error || "Failed to delete work");
+                return;
+            }
+
+            onDeleted(work.id);
+            onOpenChange(false);
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Delete Work</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to delete &quot;{work?.title}&quot;?
+                        This action cannot be undone.
+                    </DialogDescription>
+                </DialogHeader>
+                {error && (
+                    <p className="text-sm text-destructive">{error}</p>
+                )}
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => onOpenChange(false)}>
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="destructive"
+                        onClick={handleDelete}
+                        disabled={submitting}
+                    >
+                        {submitting ? "Deleting..." : "Delete"}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/app/staff/page.tsx
+++ b/src/app/staff/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth";
 import { query } from "@/lib/db";
 import { StaffWorksClient } from "./staff-works-client";
+import { StaffCheckoutsClient } from "./staff-checkouts-client";
 
 export default async function StaffPage() {
     const user = await getCurrentUser();
@@ -10,17 +11,40 @@ export default async function StaffPage() {
         redirect("/");
     }
 
-    const result = await query(
-        `SELECT id, created_at, title, date_published, publisher, editor,
-            lccn, isbn_10, isbn_13, media_type, number_of_pages, language,
-            location, updated_at
-     FROM works ORDER BY created_at DESC`
-    );
+    const [worksResult, checkoutsResult, usersResult] = await Promise.all([
+        query(
+            `SELECT id, created_at, title, date_published, publisher, editor,
+                lccn, isbn_10, isbn_13, media_type, number_of_pages, language,
+                location, updated_at
+         FROM works ORDER BY created_at DESC`
+        ),
+        query(
+            `SELECT c.id, c.work_id, c.user_id, c.checked_out_at, c.due_date,
+                    c.returned_at, c.created_at, c.updated_at,
+                    w.title AS work_title,
+                    u.name AS user_name, u.email AS user_email
+             FROM checkouts c
+             JOIN works w ON w.id = c.work_id
+             JOIN users u ON u.id = c.user_id
+             ORDER BY c.created_at DESC`
+        ),
+        query(`SELECT id, name, email FROM users ORDER BY name ASC`),
+    ]);
 
     return (
-        <div className="mx-auto max-w-7xl px-4 py-8">
-            <h1 className="mb-6 text-2xl font-bold">Item Management</h1>
-            <StaffWorksClient initialWorks={result.rows} />
+        <div className="mx-auto max-w-7xl px-4 py-8 space-y-10">
+            <section>
+                <h1 className="mb-6 text-2xl font-bold">Item Management</h1>
+                <StaffWorksClient initialWorks={worksResult.rows} />
+            </section>
+            <section>
+                <h2 className="mb-6 text-2xl font-bold">Checkouts</h2>
+                <StaffCheckoutsClient
+                    initialCheckouts={checkoutsResult.rows}
+                    works={worksResult.rows}
+                    users={usersResult.rows}
+                />
+            </section>
         </div>
     );
 }

--- a/src/app/staff/return-checkout-dialog.tsx
+++ b/src/app/staff/return-checkout-dialog.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+
+interface Checkout {
+    id: string;
+    work_title: string;
+    user_name: string;
+}
+
+interface ReturnCheckoutDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    checkout: Checkout | null;
+    onReturned: () => void;
+}
+
+export function ReturnCheckoutDialog({ open, onOpenChange, checkout, onReturned }: ReturnCheckoutDialogProps) {
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState("");
+
+    async function handleReturn() {
+        if (!checkout) return;
+        setSubmitting(true);
+        setError("");
+
+        try {
+            const res = await fetch(`/api/staff/checkouts/${checkout.id}`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ action: "return" }),
+            });
+
+            if (!res.ok) {
+                const data = await res.json();
+                setError(data.error || "Failed to return item");
+                return;
+            }
+
+            onOpenChange(false);
+            onReturned();
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Return Item</DialogTitle>
+                    <DialogDescription>
+                        Return &quot;{checkout?.work_title}&quot; from{" "}
+                        {checkout?.user_name}?
+                    </DialogDescription>
+                </DialogHeader>
+                {error && <p className="text-sm text-destructive">{error}</p>}
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => onOpenChange(false)}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleReturn} disabled={submitting}>
+                        {submitting ? "Returning..." : "Confirm Return"}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/app/staff/staff-checkouts-client.tsx
+++ b/src/app/staff/staff-checkouts-client.tsx
@@ -1,0 +1,498 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+
+interface Checkout {
+  id: string;
+  work_id: string;
+  user_id: string;
+  checked_out_at: string;
+  due_date: string;
+  returned_at: string | null;
+  work_title: string;
+  user_name: string;
+  user_email: string;
+}
+
+interface Work {
+  id: string;
+  title: string;
+}
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface StaffCheckoutsClientProps {
+  initialCheckouts: Checkout[];
+  works: Work[];
+  users: User[];
+}
+
+export function StaffCheckoutsClient({
+  initialCheckouts,
+  works,
+  users,
+}: StaffCheckoutsClientProps) {
+  const router = useRouter();
+  const checkouts = initialCheckouts;
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("active");
+  const [formOpen, setFormOpen] = useState(false);
+  const [returnOpen, setReturnOpen] = useState(false);
+  const [returningCheckout, setReturningCheckout] = useState<Checkout | null>(
+    null,
+  );
+  const [formError, setFormError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const [workListOpen, setWorkListOpen] = useState(false);
+  const [userListOpen, setUserListOpen] = useState(false);
+  const [workSearch, setWorkSearch] = useState("");
+  const [userSearch, setUserSearch] = useState("");
+
+  const [formData, setFormData] = useState({
+    work_id: "",
+    user_id: "",
+    due_date: "",
+  });
+
+  const checkedOutWorkIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const c of checkouts) {
+      if (!c.returned_at) ids.add(c.work_id);
+    }
+    return ids;
+  }, [checkouts]);
+
+  const availableWorks = useMemo(
+    () => works.filter((w) => !checkedOutWorkIds.has(w.id)),
+    [works, checkedOutWorkIds],
+  );
+
+  const filteredCheckouts = useMemo(() => {
+    return checkouts.filter((c) => {
+      const matchesSearch =
+        !search ||
+        c.work_title.toLowerCase().includes(search.toLowerCase()) ||
+        c.user_name.toLowerCase().includes(search.toLowerCase()) ||
+        c.user_email.toLowerCase().includes(search.toLowerCase());
+      const matchesStatus =
+        statusFilter === "all" ||
+        (statusFilter === "active" && !c.returned_at) ||
+        (statusFilter === "returned" && c.returned_at);
+      return matchesSearch && matchesStatus;
+    });
+  }, [checkouts, search, statusFilter]);
+
+  function defaultDueDate() {
+    const date = new Date();
+    date.setDate(date.getDate() + 30);
+    return date.toISOString().split("T")[0];
+  }
+
+  function openCheckoutDialog() {
+    setFormData({ work_id: "", user_id: "", due_date: defaultDueDate() });
+    setFormError("");
+    setWorkListOpen(false);
+    setUserListOpen(false);
+    setWorkSearch("");
+    setUserSearch("");
+    setFormOpen(true);
+  }
+
+  function openReturnDialog(checkout: Checkout) {
+    setReturningCheckout(checkout);
+    setReturnOpen(true);
+  }
+
+  function isOverdue(checkout: Checkout) {
+    return !checkout.returned_at && new Date(checkout.due_date) < new Date();
+  }
+
+  async function handleCheckout(e: React.SyntheticEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setFormError("");
+
+    try {
+      const res = await fetch("/api/staff/checkouts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setFormError(data.error || "Failed to create checkout");
+        return;
+      }
+
+      setFormOpen(false);
+      router.refresh();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleReturn() {
+    if (!returningCheckout) return;
+    setSubmitting(true);
+
+    try {
+      const res = await fetch(`/api/staff/checkouts/${returningCheckout.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "return" }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setFormError(data.error || "Failed to return item");
+        return;
+      }
+
+      setReturnOpen(false);
+      router.refresh();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-4">
+        <Button onClick={openCheckoutDialog}>Check Out Item</Button>
+        <Input
+          id="checkout-search"
+          placeholder="Search by title, name, or email..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="max-w-sm"
+        />
+        <Select name="status-filter" value={statusFilter} onValueChange={setStatusFilter}>
+          <SelectTrigger id="status-filter" className="w-[160px]">
+            <SelectValue placeholder="Filter status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="active">Active</SelectItem>
+            <SelectItem value="returned">Returned</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Work</TableHead>
+            <TableHead>Borrower</TableHead>
+            <TableHead>Checked Out</TableHead>
+            <TableHead>Due Date</TableHead>
+            {statusFilter === "returned" ? (
+              <TableHead>Returned</TableHead>
+            ) : statusFilter === "all" ? (
+              <>
+                <TableHead>Status</TableHead>
+                <TableHead className="w-[100px]">Actions</TableHead>
+              </>
+            ) : (
+              <TableHead className="w-[100px]">Actions</TableHead>
+            )}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filteredCheckouts.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={statusFilter === "all" ? 6 : 5}
+                className="text-center text-muted-foreground"
+              >
+                No checkouts found.
+              </TableCell>
+            </TableRow>
+          ) : (
+            filteredCheckouts.map((checkout) => (
+              <TableRow key={checkout.id}>
+                <TableCell className="font-medium">
+                  {checkout.work_title}
+                </TableCell>
+                <TableCell>
+                  {checkout.user_name}
+                  <span className="block text-xs text-muted-foreground">
+                    {checkout.user_email}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  {new Date(checkout.checked_out_at).toLocaleDateString()}
+                </TableCell>
+                <TableCell>
+                  {new Date(checkout.due_date).toLocaleDateString()}
+                </TableCell>
+                {statusFilter === "returned" ? (
+                  <TableCell>
+                    {checkout.returned_at
+                      ? new Date(checkout.returned_at).toLocaleDateString()
+                      : "—"}
+                  </TableCell>
+                ) : statusFilter === "all" ? (
+                  <>
+                    <TableCell>
+                      {checkout.returned_at ? (
+                        <Badge variant="secondary">Returned</Badge>
+                      ) : isOverdue(checkout) ? (
+                        <Badge variant="destructive">Overdue</Badge>
+                      ) : (
+                        <Badge>Active</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {!checkout.returned_at && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => openReturnDialog(checkout)}
+                        >
+                          Return
+                        </Button>
+                      )}
+                    </TableCell>
+                  </>
+                ) : (
+                  <TableCell>
+                    {!checkout.returned_at && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => openReturnDialog(checkout)}
+                      >
+                        Return
+                      </Button>
+                    )}
+                  </TableCell>
+                )}
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+
+      {/* Check Out Dialog */}
+      <Dialog open={formOpen} onOpenChange={setFormOpen}>
+        <DialogContent
+          className="max-w-lg"
+          onOpenAutoFocus={(e) => {
+            e.preventDefault();
+            (e.currentTarget as HTMLElement).focus();
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Check Out Item</DialogTitle>
+            <DialogDescription>
+              Select a work and a user to create a checkout.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleCheckout} className="space-y-4">
+            <div className="space-y-2">
+              <span className="text-sm font-medium">Work</span>
+              <Command className="rounded-md border" shouldFilter={workListOpen}>
+                <CommandInput
+                  name="work-search"
+                  placeholder="Search works..."
+                  hideIcon={!workListOpen && !!formData.work_id}
+                  value={workListOpen ? workSearch : (availableWorks.find((w) => w.id === formData.work_id)?.title ?? "")}
+                  onValueChange={(v) => setWorkSearch(v)}
+                  onFocus={() => {
+                    setWorkSearch("");
+                    setWorkListOpen(true);
+                  }}
+                  onBlur={() => setTimeout(() => setWorkListOpen(false), 150)}
+                />
+                {workListOpen && (
+                  <CommandList>
+                    <CommandEmpty>No works found.</CommandEmpty>
+                    <CommandGroup>
+                      {availableWorks.map((work) => (
+                        <CommandItem
+                          key={work.id}
+                          value={work.title}
+                          onSelect={() => {
+                            setFormData((prev) => ({
+                              ...prev,
+                              work_id: work.id,
+                            }));
+                            setWorkSearch("");
+                            setWorkListOpen(false);
+                          }}
+                        >
+                          <Check
+                            className={cn(
+                              "mr-2 h-4 w-4",
+                              formData.work_id === work.id
+                                ? "opacity-100"
+                                : "opacity-0",
+                            )}
+                          />
+                          {work.title}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                )}
+              </Command>
+            </div>
+            <div className="space-y-2">
+              <span className="text-sm font-medium">Borrower</span>
+              <Command className="rounded-md border" shouldFilter={userListOpen}>
+                <CommandInput
+                  name="borrower-search"
+                  placeholder="Search by name or email..."
+                  hideIcon={!userListOpen && !!formData.user_id}
+                  value={userListOpen ? userSearch : (() => {
+                    const u = users.find((u) => u.id === formData.user_id);
+                    return u ? `${u.name} (${u.email})` : "";
+                  })()}
+                  onValueChange={(v) => setUserSearch(v)}
+                  onFocus={() => {
+                    setUserSearch("");
+                    setUserListOpen(true);
+                  }}
+                  onBlur={() => setTimeout(() => setUserListOpen(false), 150)}
+                />
+                {userListOpen && (
+                  <CommandList>
+                    <CommandEmpty>No users found.</CommandEmpty>
+                    <CommandGroup>
+                      {users.map((user) => (
+                        <CommandItem
+                          key={user.id}
+                          value={`${user.name} ${user.email}`}
+                          onSelect={() => {
+                            setFormData((prev) => ({
+                              ...prev,
+                              user_id: user.id,
+                            }));
+                            setUserSearch("");
+                            setUserListOpen(false);
+                          }}
+                        >
+                          <Check
+                            className={cn(
+                              "mr-2 h-4 w-4",
+                              formData.user_id === user.id
+                                ? "opacity-100"
+                                : "opacity-0",
+                            )}
+                          />
+                          {user.name} ({user.email})
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                )}
+              </Command>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="due_date">
+                Due Date{" "}
+                <span className="text-muted-foreground font-normal">(30 days by default)</span>
+              </Label>
+              <Input
+                id="due_date"
+                type="date"
+                required
+                value={formData.due_date}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    due_date: e.target.value,
+                  }))
+                }
+              />
+            </div>
+            {formError && (
+              <p className="text-sm text-destructive">{formError}</p>
+            )}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setFormOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={submitting || !formData.work_id || !formData.user_id}
+              >
+                {submitting ? "Checking out..." : "Check Out"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Return Confirmation Dialog */}
+      <Dialog open={returnOpen} onOpenChange={setReturnOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Return Item</DialogTitle>
+            <DialogDescription>
+              Return &quot;{returningCheckout?.work_title}&quot; from{" "}
+              {returningCheckout?.user_name}?
+            </DialogDescription>
+          </DialogHeader>
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setReturnOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleReturn} disabled={submitting}>
+              {submitting ? "Returning..." : "Confirm Return"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/staff/staff-checkouts-client.tsx
+++ b/src/app/staff/staff-checkouts-client.tsx
@@ -2,11 +2,8 @@
 
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { Check } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -17,28 +14,14 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
+import { CheckoutFormDialog } from "./checkout-form-dialog";
+import { ReturnCheckoutDialog } from "./return-checkout-dialog";
 
 interface Checkout {
   id: string;
@@ -83,19 +66,6 @@ export function StaffCheckoutsClient({
   const [returningCheckout, setReturningCheckout] = useState<Checkout | null>(
     null,
   );
-  const [formError, setFormError] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-
-  const [workListOpen, setWorkListOpen] = useState(false);
-  const [userListOpen, setUserListOpen] = useState(false);
-  const [workSearch, setWorkSearch] = useState("");
-  const [userSearch, setUserSearch] = useState("");
-
-  const [formData, setFormData] = useState({
-    work_id: "",
-    user_id: "",
-    due_date: "",
-  });
 
   const checkedOutWorkIds = useMemo(() => {
     const ids = new Set<string>();
@@ -125,22 +95,6 @@ export function StaffCheckoutsClient({
     });
   }, [checkouts, search, statusFilter]);
 
-  function defaultDueDate() {
-    const date = new Date();
-    date.setDate(date.getDate() + 30);
-    return date.toISOString().split("T")[0];
-  }
-
-  function openCheckoutDialog() {
-    setFormData({ work_id: "", user_id: "", due_date: defaultDueDate() });
-    setFormError("");
-    setWorkListOpen(false);
-    setUserListOpen(false);
-    setWorkSearch("");
-    setUserSearch("");
-    setFormOpen(true);
-  }
-
   function openReturnDialog(checkout: Checkout) {
     setReturningCheckout(checkout);
     setReturnOpen(true);
@@ -150,59 +104,10 @@ export function StaffCheckoutsClient({
     return !checkout.returned_at && new Date(checkout.due_date) < new Date();
   }
 
-  async function handleCheckout(e: React.SyntheticEvent) {
-    e.preventDefault();
-    setSubmitting(true);
-    setFormError("");
-
-    try {
-      const res = await fetch("/api/staff/checkouts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(formData),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        setFormError(data.error || "Failed to create checkout");
-        return;
-      }
-
-      setFormOpen(false);
-      router.refresh();
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
-  async function handleReturn() {
-    if (!returningCheckout) return;
-    setSubmitting(true);
-
-    try {
-      const res = await fetch(`/api/staff/checkouts/${returningCheckout.id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "return" }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        setFormError(data.error || "Failed to return item");
-        return;
-      }
-
-      setReturnOpen(false);
-      router.refresh();
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-4">
-        <Button onClick={openCheckoutDialog}>Check Out Item</Button>
+        <Button onClick={() => setFormOpen(true)}>Check Out Item</Button>
         <Input
           id="checkout-search"
           placeholder="Search by title, name, or email..."
@@ -317,182 +222,20 @@ export function StaffCheckoutsClient({
         </TableBody>
       </Table>
 
-      {/* Check Out Dialog */}
-      <Dialog open={formOpen} onOpenChange={setFormOpen}>
-        <DialogContent
-          className="max-w-lg"
-          onOpenAutoFocus={(e) => {
-            e.preventDefault();
-            (e.currentTarget as HTMLElement).focus();
-          }}
-        >
-          <DialogHeader>
-            <DialogTitle>Check Out Item</DialogTitle>
-            <DialogDescription>
-              Select a work and a user to create a checkout.
-            </DialogDescription>
-          </DialogHeader>
-          <form onSubmit={handleCheckout} className="space-y-4">
-            <div className="space-y-2">
-              <span className="text-sm font-medium">Work</span>
-              <Command className="rounded-md border" shouldFilter={workListOpen}>
-                <CommandInput
-                  name="work-search"
-                  placeholder="Search works..."
-                  hideIcon={!workListOpen && !!formData.work_id}
-                  value={workListOpen ? workSearch : (availableWorks.find((w) => w.id === formData.work_id)?.title ?? "")}
-                  onValueChange={(v) => setWorkSearch(v)}
-                  onFocus={() => {
-                    setWorkSearch("");
-                    setWorkListOpen(true);
-                  }}
-                  onBlur={() => setTimeout(() => setWorkListOpen(false), 150)}
-                />
-                {workListOpen && (
-                  <CommandList>
-                    <CommandEmpty>No works found.</CommandEmpty>
-                    <CommandGroup>
-                      {availableWorks.map((work) => (
-                        <CommandItem
-                          key={work.id}
-                          value={work.title}
-                          onSelect={() => {
-                            setFormData((prev) => ({
-                              ...prev,
-                              work_id: work.id,
-                            }));
-                            setWorkSearch("");
-                            setWorkListOpen(false);
-                          }}
-                        >
-                          <Check
-                            className={cn(
-                              "mr-2 h-4 w-4",
-                              formData.work_id === work.id
-                                ? "opacity-100"
-                                : "opacity-0",
-                            )}
-                          />
-                          {work.title}
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </CommandList>
-                )}
-              </Command>
-            </div>
-            <div className="space-y-2">
-              <span className="text-sm font-medium">Borrower</span>
-              <Command className="rounded-md border" shouldFilter={userListOpen}>
-                <CommandInput
-                  name="borrower-search"
-                  placeholder="Search by name or email..."
-                  hideIcon={!userListOpen && !!formData.user_id}
-                  value={userListOpen ? userSearch : (() => {
-                    const u = users.find((u) => u.id === formData.user_id);
-                    return u ? `${u.name} (${u.email})` : "";
-                  })()}
-                  onValueChange={(v) => setUserSearch(v)}
-                  onFocus={() => {
-                    setUserSearch("");
-                    setUserListOpen(true);
-                  }}
-                  onBlur={() => setTimeout(() => setUserListOpen(false), 150)}
-                />
-                {userListOpen && (
-                  <CommandList>
-                    <CommandEmpty>No users found.</CommandEmpty>
-                    <CommandGroup>
-                      {users.map((user) => (
-                        <CommandItem
-                          key={user.id}
-                          value={`${user.name} ${user.email}`}
-                          onSelect={() => {
-                            setFormData((prev) => ({
-                              ...prev,
-                              user_id: user.id,
-                            }));
-                            setUserSearch("");
-                            setUserListOpen(false);
-                          }}
-                        >
-                          <Check
-                            className={cn(
-                              "mr-2 h-4 w-4",
-                              formData.user_id === user.id
-                                ? "opacity-100"
-                                : "opacity-0",
-                            )}
-                          />
-                          {user.name} ({user.email})
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </CommandList>
-                )}
-              </Command>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="due_date">
-                Due Date{" "}
-                <span className="text-muted-foreground font-normal">(30 days by default)</span>
-              </Label>
-              <Input
-                id="due_date"
-                type="date"
-                required
-                value={formData.due_date}
-                onChange={(e) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    due_date: e.target.value,
-                  }))
-                }
-              />
-            </div>
-            {formError && (
-              <p className="text-sm text-destructive">{formError}</p>
-            )}
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setFormOpen(false)}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                disabled={submitting || !formData.work_id || !formData.user_id}
-              >
-                {submitting ? "Checking out..." : "Check Out"}
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
+      <CheckoutFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        availableWorks={availableWorks}
+        users={users}
+        onCreated={() => router.refresh()}
+      />
 
-      {/* Return Confirmation Dialog */}
-      <Dialog open={returnOpen} onOpenChange={setReturnOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Return Item</DialogTitle>
-            <DialogDescription>
-              Return &quot;{returningCheckout?.work_title}&quot; from{" "}
-              {returningCheckout?.user_name}?
-            </DialogDescription>
-          </DialogHeader>
-          {formError && <p className="text-sm text-destructive">{formError}</p>}
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setReturnOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleReturn} disabled={submitting}>
-              {submitting ? "Returning..." : "Confirm Return"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ReturnCheckoutDialog
+        open={returnOpen}
+        onOpenChange={setReturnOpen}
+        checkout={returningCheckout}
+        onReturned={() => router.refresh()}
+      />
     </div>
   );
 }

--- a/src/app/staff/staff-works-client.tsx
+++ b/src/app/staff/staff-works-client.tsx
@@ -4,7 +4,6 @@ import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
     Table,
     TableBody,
@@ -13,14 +12,6 @@ import {
     TableHeader,
     TableRow,
 } from "@/components/ui/table";
-import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-} from "@/components/ui/dialog";
 import {
     Select,
     SelectContent,
@@ -34,6 +25,8 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { WorkFormDialog } from "./work-form-dialog";
+import { DeleteWorkDialog } from "./delete-work-dialog";
 
 interface Work {
     id: string;
@@ -67,24 +60,6 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
     const [deleteOpen, setDeleteOpen] = useState(false);
     const [editingWork, setEditingWork] = useState<Work | null>(null);
     const [deletingWork, setDeletingWork] = useState<Work | null>(null);
-    const [formError, setFormError] = useState("");
-    const [submitting, setSubmitting] = useState(false);
-
-    const emptyForm = {
-        title: "",
-        date_published: "",
-        publisher: "",
-        editor: "",
-        lccn: "",
-        isbn_10: "",
-        isbn_13: "",
-        media_type: "",
-        number_of_pages: "",
-        language: "",
-        location: "",
-    };
-
-    const [formData, setFormData] = useState(emptyForm);
 
     const filteredWorks = useMemo(() => {
         return works.filter((work) => {
@@ -100,27 +75,11 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
 
     function openAddDialog() {
         setEditingWork(null);
-        setFormData(emptyForm);
-        setFormError("");
         setFormOpen(true);
     }
 
     function openEditDialog(work: Work) {
         setEditingWork(work);
-        setFormData({
-            title: work.title,
-            date_published: work.date_published ?? "",
-            publisher: work.publisher ?? "",
-            editor: work.editor ?? "",
-            lccn: work.lccn ?? "",
-            isbn_10: work.isbn_10 ?? "",
-            isbn_13: work.isbn_13 ?? "",
-            media_type: work.media_type ?? "",
-            number_of_pages: work.number_of_pages?.toString() ?? "",
-            language: work.language ?? "",
-            location: work.location ?? "",
-        });
-        setFormError("");
         setFormOpen(true);
     }
 
@@ -129,102 +88,18 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
         setDeleteOpen(true);
     }
 
-    async function handleSubmit(e: React.SyntheticEvent) {
-        e.preventDefault();
-        setSubmitting(true);
-        setFormError("");
-
-        try {
-            if (editingWork) {
-                const updates: Record<string, string> = {};
-                if (formData.title !== editingWork.title) updates.title = formData.title;
-                if (formData.date_published !== (editingWork.date_published ?? ""))
-                    updates.date_published = formData.date_published;
-                if (formData.publisher !== (editingWork.publisher ?? ""))
-                    updates.publisher = formData.publisher;
-                if (formData.editor !== (editingWork.editor ?? ""))
-                    updates.editor = formData.editor;
-                if (formData.lccn !== (editingWork.lccn ?? ""))
-                    updates.lccn = formData.lccn;
-                if (formData.isbn_10 !== (editingWork.isbn_10 ?? ""))
-                    updates.isbn_10 = formData.isbn_10;
-                if (formData.isbn_13 !== (editingWork.isbn_13 ?? ""))
-                    updates.isbn_13 = formData.isbn_13;
-                if (formData.media_type !== (editingWork.media_type ?? ""))
-                    updates.media_type = formData.media_type;
-                if (formData.number_of_pages !== (editingWork.number_of_pages?.toString() ?? ""))
-                    updates.number_of_pages = formData.number_of_pages;
-                if (formData.language !== (editingWork.language ?? ""))
-                    updates.language = formData.language;
-                if (formData.location !== (editingWork.location ?? ""))
-                    updates.location = formData.location;
-
-                if (Object.keys(updates).length === 0) {
-                    setFormOpen(false);
-                    return;
-                }
-
-                const res = await fetch(`/api/staff/works/${editingWork.id}`, {
-                    method: "PUT",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify(updates),
-                });
-
-                if (!res.ok) {
-                    const data = await res.json();
-                    setFormError(data.error || "Failed to update work");
-                    return;
-                }
-
-                const updated = await res.json();
-                setWorks((prev) =>
-                    prev.map((w) => (w.id === updated.id ? updated : w))
-                );
-            } else {
-                const res = await fetch("/api/staff/works", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify(formData),
-                });
-
-                if (!res.ok) {
-                    const data = await res.json();
-                    setFormError(data.error || "Failed to create work");
-                    return;
-                }
-
-                const created = await res.json();
-                setWorks((prev) => [created, ...prev]);
-            }
-
-            setFormOpen(false);
-            router.refresh();
-        } finally {
-            setSubmitting(false);
+    function handleSaved(work: Work, isNew: boolean) {
+        if (isNew) {
+            setWorks((prev) => [work, ...prev]);
+        } else {
+            setWorks((prev) => prev.map((w) => (w.id === work.id ? work : w)));
         }
+        router.refresh();
     }
 
-    async function handleDelete() {
-        if (!deletingWork) return;
-        setSubmitting(true);
-
-        try {
-            const res = await fetch(`/api/staff/works/${deletingWork.id}`, {
-                method: "DELETE",
-            });
-
-            if (!res.ok) {
-                const data = await res.json();
-                setFormError(data.error || "Failed to delete work");
-                return;
-            }
-
-            setWorks((prev) => prev.filter((w) => w.id !== deletingWork.id));
-            setDeleteOpen(false);
-            router.refresh();
-        } finally {
-            setSubmitting(false);
-        }
+    function handleDeleted(id: string) {
+        setWorks((prev) => prev.filter((w) => w.id !== id));
+        router.refresh();
     }
 
     return (
@@ -307,232 +182,19 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
                 </TableBody>
             </Table>
 
-            {/* Add / Edit Dialog */}
-            <Dialog open={formOpen} onOpenChange={setFormOpen}>
-                <DialogContent className="max-w-lg">
-                    <DialogHeader>
-                        <DialogTitle>
-                            {editingWork ? "Edit Work" : "Add Work"}
-                        </DialogTitle>
-                        <DialogDescription>
-                            {editingWork
-                                ? "Update the work's details below."
-                                : "Fill in the details to create a new work."}
-                        </DialogDescription>
-                    </DialogHeader>
-                    <form onSubmit={handleSubmit} className="space-y-4">
-                        <div className="space-y-2">
-                            <Label htmlFor="title">Title</Label>
-                            <Input
-                                id="title"
-                                required
-                                value={formData.title}
-                                onChange={(e) =>
-                                    setFormData((prev) => ({ ...prev, title: e.target.value }))
-                                }
-                            />
-                        </div>
-                        <div className="grid grid-cols-2 gap-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="publisher">Publisher</Label>
-                                <Input
-                                    id="publisher"
-                                    value={formData.publisher}
-                                    onChange={(e) =>
-                                        setFormData((prev) => ({
-                                            ...prev,
-                                            publisher: e.target.value,
-                                        }))
-                                    }
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="editor">Editor</Label>
-                                <Input
-                                    id="editor"
-                                    value={formData.editor}
-                                    onChange={(e) =>
-                                        setFormData((prev) => ({
-                                            ...prev,
-                                            editor: e.target.value,
-                                        }))
-                                    }
-                                />
-                            </div>
-                        </div>
-                        <div className="grid grid-cols-2 gap-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="date_published">Date Published</Label>
-                                <Input
-                                    id="date_published"
-                                    placeholder="e.g. 2024-01-15"
-                                    value={formData.date_published}
-                                    onChange={(e) =>
-                                        setFormData((prev) => ({
-                                            ...prev,
-                                            date_published: e.target.value,
-                                        }))
-                                    }
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="media-type">Media Type</Label>
-                                <Select
-                                    name="media-type"
-                                    value={formData.media_type}
-                                    onValueChange={(value) =>
-                                        setFormData((prev) => ({ ...prev, media_type: value }))
-                                    }
-                                >
-                                    <SelectTrigger id="media-type">
-                                        <SelectValue placeholder="Select type" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {MEDIA_TYPES.map((type) => (
-                                            <SelectItem key={type} value={type}>
-                                                {type.charAt(0).toUpperCase() + type.slice(1)}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </div>
-                        </div>
-                        <div className="grid grid-cols-2 gap-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="isbn_10">ISBN-10</Label>
-                                <Input
-                                    id="isbn_10"
-                                    value={formData.isbn_10}
-                                    onChange={(e) =>
-                                        setFormData((prev) => ({
-                                            ...prev,
-                                            isbn_10: e.target.value,
-                                        }))
-                                    }
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="isbn_13">ISBN-13</Label>
-                                <Input
-                                    id="isbn_13"
-                                    value={formData.isbn_13}
-                                    onChange={(e) =>
-                                        setFormData((prev) => ({
-                                            ...prev,
-                                            isbn_13: e.target.value,
-                                        }))
-                                    }
-                                />
-                            </div>
-                        </div>
-                        <div className="grid grid-cols-2 gap-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="lccn">LCCN</Label>
-                                <Input
-                                    id="lccn"
-                                    value={formData.lccn}
-                                    onChange={(e) =>
-                                        setFormData((prev) => ({
-                                            ...prev,
-                                            lccn: e.target.value,
-                                        }))
-                                    }
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="location">Location</Label>
-                                <Input
-                                    id="location"
-                                    value={formData.location}
-                                    onChange={(e) =>
-                                        setFormData((prev) => ({
-                                            ...prev,
-                                            location: e.target.value,
-                                        }))
-                                    }
-                                />
-                            </div>
-                        </div>
-                        <div className="grid grid-cols-2 gap-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="number_of_pages">Number of Pages</Label>
-                                <Input
-                                    id="number_of_pages"
-                                    type="number"
-                                    value={formData.number_of_pages}
-                                    onChange={(e) =>
-                                        setFormData((prev) => ({
-                                            ...prev,
-                                            number_of_pages: e.target.value,
-                                        }))
-                                    }
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="language">Language</Label>
-                                <Input
-                                    id="language"
-                                    placeholder="e.g. English"
-                                    value={formData.language}
-                                    onChange={(e) =>
-                                        setFormData((prev) => ({
-                                            ...prev,
-                                            language: e.target.value,
-                                        }))
-                                    }
-                                />
-                            </div>
-                        </div>
-                        {formError && (
-                            <p className="text-sm text-destructive">{formError}</p>
-                        )}
-                        <DialogFooter>
-                            <Button
-                                type="button"
-                                variant="outline"
-                                onClick={() => setFormOpen(false)}
-                            >
-                                Cancel
-                            </Button>
-                            <Button type="submit" disabled={submitting}>
-                                {submitting
-                                    ? "Saving..."
-                                    : editingWork
-                                        ? "Save Changes"
-                                        : "Create Work"}
-                            </Button>
-                        </DialogFooter>
-                    </form>
-                </DialogContent>
-            </Dialog>
+            <WorkFormDialog
+                open={formOpen}
+                onOpenChange={setFormOpen}
+                editingWork={editingWork}
+                onSaved={handleSaved}
+            />
 
-            {/* Delete Confirmation Dialog */}
-            <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Delete Work</DialogTitle>
-                        <DialogDescription>
-                            Are you sure you want to delete &quot;{deletingWork?.title}&quot;?
-                            This action cannot be undone.
-                        </DialogDescription>
-                    </DialogHeader>
-                    {formError && (
-                        <p className="text-sm text-destructive">{formError}</p>
-                    )}
-                    <DialogFooter>
-                        <Button variant="outline" onClick={() => setDeleteOpen(false)}>
-                            Cancel
-                        </Button>
-                        <Button
-                            variant="destructive"
-                            onClick={handleDelete}
-                            disabled={submitting}
-                        >
-                            {submitting ? "Deleting..." : "Delete"}
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
+            <DeleteWorkDialog
+                open={deleteOpen}
+                onOpenChange={setDeleteOpen}
+                work={deletingWork}
+                onDeleted={handleDeleted}
+            />
         </div>
     );
 }

--- a/src/app/staff/staff-works-client.tsx
+++ b/src/app/staff/staff-works-client.tsx
@@ -232,13 +232,14 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
             <div className="flex items-center gap-4">
                 <Button onClick={openAddDialog}>Add Item</Button>
                 <Input
+                    id="works-search"
                     placeholder="Search by title or publisher..."
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     className="max-w-sm"
                 />
-                <Select value={mediaFilter} onValueChange={setMediaFilter}>
-                    <SelectTrigger className="w-[160px]">
+                <Select name="media-filter" value={mediaFilter} onValueChange={setMediaFilter}>
+                    <SelectTrigger id="media-filter" className="w-[160px]">
                         <SelectValue placeholder="Filter media type" />
                     </SelectTrigger>
                     <SelectContent>
@@ -375,14 +376,15 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
                                 />
                             </div>
                             <div className="space-y-2">
-                                <Label htmlFor="media_type">Media Type</Label>
+                                <Label htmlFor="media-type">Media Type</Label>
                                 <Select
+                                    name="media-type"
                                     value={formData.media_type}
                                     onValueChange={(value) =>
                                         setFormData((prev) => ({ ...prev, media_type: value }))
                                     }
                                 >
-                                    <SelectTrigger>
+                                    <SelectTrigger id="media-type">
                                         <SelectValue placeholder="Select type" />
                                     </SelectTrigger>
                                     <SelectContent>

--- a/src/app/staff/work-form-dialog.tsx
+++ b/src/app/staff/work-form-dialog.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+
+interface Work {
+    id: string;
+    title: string;
+    date_published: string | null;
+    publisher: string | null;
+    editor: string | null;
+    lccn: string | null;
+    isbn_10: string | null;
+    isbn_13: string | null;
+    media_type: string | null;
+    number_of_pages: number | null;
+    language: string | null;
+    location: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+interface WorkFormDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    editingWork: Work | null;
+    onSaved: (work: Work, isNew: boolean) => void;
+}
+
+const MEDIA_TYPES = ["book", "ebook", "audiobook", "periodical", "dvd", "other"];
+
+const emptyForm = {
+    title: "",
+    date_published: "",
+    publisher: "",
+    editor: "",
+    lccn: "",
+    isbn_10: "",
+    isbn_13: "",
+    media_type: "",
+    number_of_pages: "",
+    language: "",
+    location: "",
+};
+
+export function WorkFormDialog({ open, onOpenChange, editingWork, onSaved }: WorkFormDialogProps) {
+    const [formData, setFormData] = useState(emptyForm);
+    const [formError, setFormError] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (!open) return;
+        setFormError("");
+        if (editingWork) {
+            setFormData({
+                title: editingWork.title,
+                date_published: editingWork.date_published ?? "",
+                publisher: editingWork.publisher ?? "",
+                editor: editingWork.editor ?? "",
+                lccn: editingWork.lccn ?? "",
+                isbn_10: editingWork.isbn_10 ?? "",
+                isbn_13: editingWork.isbn_13 ?? "",
+                media_type: editingWork.media_type ?? "",
+                number_of_pages: editingWork.number_of_pages?.toString() ?? "",
+                language: editingWork.language ?? "",
+                location: editingWork.location ?? "",
+            });
+        } else {
+            setFormData(emptyForm);
+        }
+    }, [open, editingWork]);
+
+    async function handleSubmit(e: React.SyntheticEvent) {
+        e.preventDefault();
+        setSubmitting(true);
+        setFormError("");
+
+        try {
+            if (editingWork) {
+                const updates: Record<string, string> = {};
+                if (formData.title !== editingWork.title) updates.title = formData.title;
+                if (formData.date_published !== (editingWork.date_published ?? ""))
+                    updates.date_published = formData.date_published;
+                if (formData.publisher !== (editingWork.publisher ?? ""))
+                    updates.publisher = formData.publisher;
+                if (formData.editor !== (editingWork.editor ?? ""))
+                    updates.editor = formData.editor;
+                if (formData.lccn !== (editingWork.lccn ?? ""))
+                    updates.lccn = formData.lccn;
+                if (formData.isbn_10 !== (editingWork.isbn_10 ?? ""))
+                    updates.isbn_10 = formData.isbn_10;
+                if (formData.isbn_13 !== (editingWork.isbn_13 ?? ""))
+                    updates.isbn_13 = formData.isbn_13;
+                if (formData.media_type !== (editingWork.media_type ?? ""))
+                    updates.media_type = formData.media_type;
+                if (formData.number_of_pages !== (editingWork.number_of_pages?.toString() ?? ""))
+                    updates.number_of_pages = formData.number_of_pages;
+                if (formData.language !== (editingWork.language ?? ""))
+                    updates.language = formData.language;
+                if (formData.location !== (editingWork.location ?? ""))
+                    updates.location = formData.location;
+
+                if (Object.keys(updates).length === 0) {
+                    onOpenChange(false);
+                    return;
+                }
+
+                const res = await fetch(`/api/staff/works/${editingWork.id}`, {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(updates),
+                });
+
+                if (!res.ok) {
+                    const data = await res.json();
+                    setFormError(data.error || "Failed to update work");
+                    return;
+                }
+
+                const updated = await res.json();
+                onSaved(updated, false);
+            } else {
+                const res = await fetch("/api/staff/works", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(formData),
+                });
+
+                if (!res.ok) {
+                    const data = await res.json();
+                    setFormError(data.error || "Failed to create work");
+                    return;
+                }
+
+                const created = await res.json();
+                onSaved(created, true);
+            }
+
+            onOpenChange(false);
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>
+                        {editingWork ? "Edit Work" : "Add Work"}
+                    </DialogTitle>
+                    <DialogDescription>
+                        {editingWork
+                            ? "Update the work's details below."
+                            : "Fill in the details to create a new work."}
+                    </DialogDescription>
+                </DialogHeader>
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="title">Title</Label>
+                        <Input
+                            id="title"
+                            required
+                            value={formData.title}
+                            onChange={(e) =>
+                                setFormData((prev) => ({ ...prev, title: e.target.value }))
+                            }
+                        />
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="publisher">Publisher</Label>
+                            <Input
+                                id="publisher"
+                                value={formData.publisher}
+                                onChange={(e) =>
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        publisher: e.target.value,
+                                    }))
+                                }
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="editor">Editor</Label>
+                            <Input
+                                id="editor"
+                                value={formData.editor}
+                                onChange={(e) =>
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        editor: e.target.value,
+                                    }))
+                                }
+                            />
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="date_published">Date Published</Label>
+                            <Input
+                                id="date_published"
+                                placeholder="e.g. 2024-01-15"
+                                value={formData.date_published}
+                                onChange={(e) =>
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        date_published: e.target.value,
+                                    }))
+                                }
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="media-type">Media Type</Label>
+                            <Select
+                                name="media-type"
+                                value={formData.media_type}
+                                onValueChange={(value) =>
+                                    setFormData((prev) => ({ ...prev, media_type: value }))
+                                }
+                            >
+                                <SelectTrigger id="media-type">
+                                    <SelectValue placeholder="Select type" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {MEDIA_TYPES.map((type) => (
+                                        <SelectItem key={type} value={type}>
+                                            {type.charAt(0).toUpperCase() + type.slice(1)}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="isbn_10">ISBN-10</Label>
+                            <Input
+                                id="isbn_10"
+                                value={formData.isbn_10}
+                                onChange={(e) =>
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        isbn_10: e.target.value,
+                                    }))
+                                }
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="isbn_13">ISBN-13</Label>
+                            <Input
+                                id="isbn_13"
+                                value={formData.isbn_13}
+                                onChange={(e) =>
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        isbn_13: e.target.value,
+                                    }))
+                                }
+                            />
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="lccn">LCCN</Label>
+                            <Input
+                                id="lccn"
+                                value={formData.lccn}
+                                onChange={(e) =>
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        lccn: e.target.value,
+                                    }))
+                                }
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="location">Location</Label>
+                            <Input
+                                id="location"
+                                value={formData.location}
+                                onChange={(e) =>
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        location: e.target.value,
+                                    }))
+                                }
+                            />
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="number_of_pages">Number of Pages</Label>
+                            <Input
+                                id="number_of_pages"
+                                type="number"
+                                value={formData.number_of_pages}
+                                onChange={(e) =>
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        number_of_pages: e.target.value,
+                                    }))
+                                }
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="language">Language</Label>
+                            <Input
+                                id="language"
+                                placeholder="e.g. English"
+                                value={formData.language}
+                                onChange={(e) =>
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        language: e.target.value,
+                                    }))
+                                }
+                            />
+                        </div>
+                    </div>
+                    {formError && (
+                        <p className="text-sm text-destructive">{formError}</p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={submitting}>
+                            {submitting
+                                ? "Saving..."
+                                : editingWork
+                                    ? "Save Changes"
+                                    : "Create Work"}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  hideIcon,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input> & { hideIcon?: boolean }) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      {!hideIcon && <SearchIcon className="size-4 shrink-0 opacity-50" />}
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/src/lib/migrations/002_create_checkouts_table.sql
+++ b/src/lib/migrations/002_create_checkouts_table.sql
@@ -1,0 +1,20 @@
+-- Create checkouts table
+CREATE TABLE IF NOT EXISTS checkouts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  work_id BIGINT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  checked_out_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  due_date TIMESTAMPTZ NOT NULL,
+  returned_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for looking up checkouts by work
+CREATE INDEX IF NOT EXISTS idx_checkouts_work_id ON checkouts(work_id);
+
+-- Index for looking up checkouts by user
+CREATE INDEX IF NOT EXISTS idx_checkouts_user_id ON checkouts(user_id);
+
+-- Index for finding active (not returned) checkouts
+CREATE INDEX IF NOT EXISTS idx_checkouts_returned_at ON checkouts(returned_at);

--- a/tsconfig.migrate.json
+++ b/tsconfig.migrate.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
## Summary
- Implements **S5 (Check out/in book)** — staff can check out items to users and process returns
- Implements **S11 (View checked out books)** — staff can view all checkouts with status filtering

## Changes
- `POST /api/staff/checkouts` — create new checkout
- `PUT /api/staff/checkouts/[id]` — process return (sets `returned_at`)
- `GET /api/staff/checkouts` — list all checkouts with work/user details
- Staff page now has two tabs: Works and Checkouts
- Checkouts UI with combobox selectors, status filtering (all/active/returned), and overdue badges
- Migration for `checkouts` table with foreign keys to works and users
- 17 new test cases covering checkout API routes
- Refactored staff client components by extracting dialogs into separate files

## Test plan
- [x] All 80 tests pass
- [x] Staff can check out available works to users
- [x] Staff can process returns
- [x] Checkouts table shows active/returned/overdue status
- [x] Combobox filtering works for works and users
- [x] Only available (non-checked-out) works appear in checkout dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)