### PR TITLE
view book: implement public book details page with staff editing

### DIFF
--- a/src/__tests__/lib/data/works.test.ts
+++ b/src/__tests__/lib/data/works.test.ts
@@ -23,6 +23,7 @@ import {
     createWork,
     updateWork,
     deleteWork,
+    getPublicWorkById,
 } from "@/lib/data/works";
 
 const staffUser = {
@@ -136,6 +137,34 @@ describe("getWorkById", () => {
         mockQuery.mockResolvedValue({ rows: [] });
 
         const result = await getWorkById("w999");
+
+        expect(result).toBeNull();
+    });
+});
+
+// ─── getPublicWorkById ────────────────────────────────────────────────
+
+describe("getPublicWorkById", () => {
+    it("returns a work with cover data without throwing Unauthorized", async () => {
+        // Even if user is null, it should not throw
+        mockGetCurrentUser.mockResolvedValue(null);
+
+        const work = { id: "w1", title: "Book A", cover: "base64data" };
+        mockQuery.mockResolvedValue({ rows: [work] });
+
+        const result = await getPublicWorkById("w1");
+
+        expect(result).toEqual(work);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("encode(cover"),
+            ["w1"]
+        );
+    });
+
+    it("returns null when work not found", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        const result = await getPublicWorkById("w999");
 
         expect(result).toBeNull();
     });

--- a/src/app/admin/admin-users-client.tsx
+++ b/src/app/admin/admin-users-client.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Search } from "lucide-react";
 
 interface User {
   id: string;
@@ -201,12 +202,15 @@ export function AdminUsersClient({
     <div className="space-y-4">
       <div className="flex items-center gap-4">
         <Button onClick={openAddDialog}>Add User</Button>
-        <Input
-          placeholder="Search by name or email..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="max-w-sm"
-        />
+        <div className="relative max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by name or email..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
         <Select value={roleFilter} onValueChange={setRoleFilter}>
           <SelectTrigger className="w-[140px]">
             <SelectValue placeholder="Filter role" />

--- a/src/app/search/search-client.tsx
+++ b/src/app/search/search-client.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
     Select,
     SelectContent,
@@ -10,6 +13,22 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import {
+    LayoutGrid,
+    List,
+    ArrowUp,
+    ArrowDown,
+    ArrowUpDown,
+    Search,
+} from "lucide-react";
 
 interface Work {
     id: string;
@@ -24,9 +43,53 @@ interface Work {
     number_of_pages: number | null;
     language: string | null;
     location: string | null;
+    call_number: string | null;
 }
 
+type ViewMode = "grid" | "list";
+type SortField =
+    | "title"
+    | "call_number"
+    | "date_published"
+    | "media_type"
+    | "number_of_pages";
+type SortDirection = "asc" | "desc";
+
 const MEDIA_TYPES = ["book", "ebook", "audiobook", "periodical", "dvd", "other"];
+
+const SORT_FIELD_LABELS: Record<SortField, string> = {
+    title: "Title",
+    call_number: "Call Number",
+    date_published: "Date Published",
+    media_type: "Media Type",
+    number_of_pages: "Pages",
+};
+
+function extractYear(date: string): string {
+    const match = date.match(/(\d{4})/);
+    return match ? match[1] : date;
+}
+
+function compareValues(
+    a: string | number | null | undefined,
+    b: string | number | null | undefined,
+    direction: SortDirection
+): number {
+    // Nulls always go to the end
+    if (a == null && b == null) return 0;
+    if (a == null) return 1;
+    if (b == null) return -1;
+
+    let result: number;
+    if (typeof a === "number" && typeof b === "number") {
+        result = a - b;
+    } else {
+        result = String(a).localeCompare(String(b), undefined, {
+            sensitivity: "base",
+        });
+    }
+    return direction === "asc" ? result : -result;
+}
 
 export function SearchClient() {
     const [query, setQuery] = useState("");
@@ -34,6 +97,14 @@ export function SearchClient() {
     const [results, setResults] = useState<Work[]>([]);
     const [loading, setLoading] = useState(false);
     const [hasSearched, setHasSearched] = useState(false);
+
+    // New state
+    const [viewMode, setViewMode] = useState<ViewMode>("grid");
+    const [sortField, setSortField] = useState<SortField>("title");
+    const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+    const [languageFilter, setLanguageFilter] = useState("all");
+
+    const router = useRouter();
 
     const fetchResults = useCallback(async (q: string, media: string) => {
         setLoading(true);
@@ -61,30 +132,167 @@ export function SearchClient() {
         return () => clearTimeout(timer);
     }, [query, mediaFilter, fetchResults]);
 
+    // Distinct languages for filter dropdown
+    const availableLanguages = useMemo(() => {
+        const langs = new Set<string>();
+        results.forEach((w) => {
+            if (w.language) langs.add(w.language);
+        });
+        return Array.from(langs).sort();
+    }, [results]);
+
+    // Client-side filtering + sorting
+    const processedResults = useMemo(() => {
+        let filtered = results;
+
+        if (languageFilter && languageFilter !== "all") {
+            filtered = filtered.filter((w) => w.language === languageFilter);
+        }
+
+        const sorted = [...filtered].sort((a, b) =>
+            compareValues(a[sortField], b[sortField], sortDirection)
+        );
+
+        return sorted;
+    }, [results, languageFilter, sortField, sortDirection]);
+
+    function handleColumnSort(field: SortField) {
+        if (sortField === field) {
+            setSortDirection((d) => (d === "asc" ? "desc" : "asc"));
+        } else {
+            setSortField(field);
+            setSortDirection("asc");
+        }
+    }
+
+    function renderSortIcon(field: SortField) {
+        if (sortField !== field) {
+            return <ArrowUpDown className="ml-1 h-3 w-3 opacity-40" />;
+        }
+        return sortDirection === "asc" ? (
+            <ArrowUp className="ml-1 h-3 w-3" />
+        ) : (
+            <ArrowDown className="ml-1 h-3 w-3" />
+        );
+    }
+
     return (
         <div className="space-y-6">
             {/* Search controls */}
-            <div className="flex flex-col sm:flex-row gap-4">
-                <Input
-                    id="search-input"
-                    placeholder="Search by title, publisher, editor, ISBN, or LCCN..."
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
-                    className="flex-1"
-                />
-                <Select value={mediaFilter} onValueChange={setMediaFilter}>
-                    <SelectTrigger id="media-filter" className="w-full sm:w-[180px]">
-                        <SelectValue placeholder="All Types" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value="all">All Types</SelectItem>
-                        {MEDIA_TYPES.map((type) => (
-                            <SelectItem key={type} value={type}>
-                                {type.charAt(0).toUpperCase() + type.slice(1)}
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
+            <div className="flex flex-col gap-4">
+                {/* Row 1: Search input */}
+                <div className="relative">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                    <Input
+                        id="search-input"
+                        placeholder="Search by title, publisher, editor, ISBN, or LCCN..."
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        className="pl-9"
+                    />
+                </div>
+
+                {/* Row 2: Filters, sort, and view toggle */}
+                <div className="flex flex-wrap items-center gap-3">
+                    {/* Media type filter */}
+                    <Select value={mediaFilter} onValueChange={setMediaFilter}>
+                        <SelectTrigger id="media-filter" className="w-[160px]">
+                            <SelectValue placeholder="All Types" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="all">All Types</SelectItem>
+                            {MEDIA_TYPES.map((type) => (
+                                <SelectItem key={type} value={type}>
+                                    {type.charAt(0).toUpperCase() + type.slice(1)}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+
+                    {/* Language filter */}
+                    <Select value={languageFilter} onValueChange={setLanguageFilter}>
+                        <SelectTrigger id="language-filter" className="w-[160px]">
+                            <SelectValue placeholder="All Languages" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="all">All Languages</SelectItem>
+                            {availableLanguages.map((lang) => (
+                                <SelectItem key={lang} value={lang}>
+                                    {lang}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+
+                    {/* Sort field */}
+                    <Select
+                        value={sortField}
+                        onValueChange={(v) => setSortField(v as SortField)}
+                    >
+                        <SelectTrigger id="sort-field" className="w-[170px]">
+                            <SelectValue placeholder="Sort by..." />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {Object.entries(SORT_FIELD_LABELS).map(
+                                ([value, label]) => (
+                                    <SelectItem key={value} value={value}>
+                                        {label}
+                                    </SelectItem>
+                                )
+                            )}
+                        </SelectContent>
+                    </Select>
+
+                    {/* Sort direction */}
+                    <Button
+                        id="sort-direction"
+                        variant="outline"
+                        size="icon"
+                        onClick={() =>
+                            setSortDirection((d) =>
+                                d === "asc" ? "desc" : "asc"
+                            )
+                        }
+                        title={
+                            sortDirection === "asc"
+                                ? "Ascending — click to reverse"
+                                : "Descending — click to reverse"
+                        }
+                    >
+                        {sortDirection === "asc" ? (
+                            <ArrowUp className="h-4 w-4" />
+                        ) : (
+                            <ArrowDown className="h-4 w-4" />
+                        )}
+                    </Button>
+
+                    {/* Spacer pushes view toggle to the right */}
+                    <div className="flex-1" />
+
+                    {/* View toggle */}
+                    <div className="flex rounded-md border">
+                        <Button
+                            id="view-grid"
+                            variant={viewMode === "grid" ? "default" : "ghost"}
+                            size="icon"
+                            className="rounded-r-none"
+                            onClick={() => setViewMode("grid")}
+                            title="Grid view"
+                        >
+                            <LayoutGrid className="h-4 w-4" />
+                        </Button>
+                        <Button
+                            id="view-list"
+                            variant={viewMode === "list" ? "default" : "ghost"}
+                            size="icon"
+                            className="rounded-l-none"
+                            onClick={() => setViewMode("list")}
+                            title="List view"
+                        >
+                            <List className="h-4 w-4" />
+                        </Button>
+                    </div>
+                </div>
             </div>
 
             {/* Loading state */}
@@ -95,87 +303,225 @@ export function SearchClient() {
             )}
 
             {/* Results */}
-            {!loading && hasSearched && results.length === 0 && (
+            {!loading && hasSearched && processedResults.length === 0 && (
                 <div className="text-center py-12">
                     <p className="text-lg text-muted-foreground">No results found.</p>
                     <p className="text-sm text-muted-foreground mt-1">
-                        Try a different search term or remove the media type filter.
+                        Try a different search term or adjust your filters.
                     </p>
                 </div>
             )}
 
-            {!loading && results.length > 0 && (
+            {!loading && processedResults.length > 0 && (
                 <>
                     <p className="text-sm text-muted-foreground">
-                        {results.length} result{results.length !== 1 ? "s" : ""} found
+                        {processedResults.length} result
+                        {processedResults.length !== 1 ? "s" : ""} found
+                        {languageFilter !== "all" &&
+                            ` (filtered from ${results.length})`}
                     </p>
-                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                        {results.map((work) => (
-                            <div
-                                key={work.id}
-                                className="rounded-lg border bg-card p-5 shadow-sm hover:shadow-md transition-shadow"
-                            >
-                                <div className="flex items-start justify-between gap-2 mb-3">
-                                    <h2 className="font-semibold text-lg leading-tight">
-                                        {work.title}
-                                    </h2>
-                                    {work.media_type && (
-                                        <Badge variant="secondary" className="shrink-0">
-                                            {work.media_type.charAt(0).toUpperCase() +
-                                                work.media_type.slice(1)}
-                                        </Badge>
-                                    )}
-                                </div>
 
-                                <div className="space-y-1 text-sm text-muted-foreground">
-                                    {work.publisher && (
-                                        <p>
-                                            <span className="font-medium text-foreground">Publisher:</span>{" "}
-                                            {work.publisher}
-                                        </p>
-                                    )}
-                                    {work.editor && (
-                                        <p>
-                                            <span className="font-medium text-foreground">Editor:</span>{" "}
-                                            {work.editor}
-                                        </p>
-                                    )}
-                                    {work.date_published && (
-                                        <p>
-                                            <span className="font-medium text-foreground">Published:</span>{" "}
-                                            {new Date(work.date_published).toLocaleDateString()}
-                                        </p>
-                                    )}
-                                    {work.language && (
-                                        <p>
-                                            <span className="font-medium text-foreground">Language:</span>{" "}
-                                            {work.language}
-                                        </p>
-                                    )}
-                                    {work.number_of_pages && (
-                                        <p>
-                                            <span className="font-medium text-foreground">Pages:</span>{" "}
-                                            {work.number_of_pages}
-                                        </p>
-                                    )}
-                                    {work.location && (
-                                        <p>
-                                            <span className="font-medium text-foreground">Location:</span>{" "}
-                                            {work.location}
-                                        </p>
-                                    )}
-                                </div>
-
-                                {(work.isbn_10 || work.isbn_13 || work.lccn) && (
-                                    <div className="mt-3 pt-3 border-t text-xs text-muted-foreground space-y-0.5">
-                                        {work.isbn_10 && <p>ISBN-10: {work.isbn_10}</p>}
-                                        {work.isbn_13 && <p>ISBN-13: {work.isbn_13}</p>}
-                                        {work.lccn && <p>LCCN: {work.lccn}</p>}
+                    {/* ====== GRID VIEW ====== */}
+                    {viewMode === "grid" && (
+                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                            {processedResults.map((work) => (
+                                <Link
+                                    key={work.id}
+                                    href={`/works/${work.id}`}
+                                    className="block rounded-lg border bg-card p-5 shadow-sm hover:shadow-md transition-shadow focus:outline-none focus:ring-2 focus:ring-ring"
+                                >
+                                    <div className="flex items-start justify-between gap-2 mb-3">
+                                        <h2 className="font-semibold text-lg leading-tight">
+                                            {work.title}
+                                        </h2>
+                                        {work.media_type && (
+                                            <Badge
+                                                variant="secondary"
+                                                className="shrink-0"
+                                            >
+                                                {work.media_type
+                                                    .charAt(0)
+                                                    .toUpperCase() +
+                                                    work.media_type.slice(1)}
+                                            </Badge>
+                                        )}
                                     </div>
-                                )}
-                            </div>
-                        ))}
-                    </div>
+
+                                    <div className="space-y-1 text-sm text-muted-foreground">
+                                        {work.call_number && (
+                                            <p>
+                                                <span className="font-medium text-foreground">
+                                                    Call Number:
+                                                </span>{" "}
+                                                {work.call_number}
+                                            </p>
+                                        )}
+                                        {work.editor && (
+                                            <p>
+                                                <span className="font-medium text-foreground">
+                                                    Editor:
+                                                </span>{" "}
+                                                {work.editor}
+                                            </p>
+                                        )}
+                                        {work.date_published && (
+                                            <p>
+                                                <span className="font-medium text-foreground">
+                                                    Published:
+                                                </span>{" "}
+                                                {extractYear(work.date_published)}
+                                            </p>
+                                        )}
+                                        {work.language && (
+                                            <p>
+                                                <span className="font-medium text-foreground">
+                                                    Language:
+                                                </span>{" "}
+                                                {work.language}
+                                            </p>
+                                        )}
+                                        {work.number_of_pages && (
+                                            <p>
+                                                <span className="font-medium text-foreground">
+                                                    Pages:
+                                                </span>{" "}
+                                                {work.number_of_pages}
+                                            </p>
+                                        )}
+                                        {work.location && (
+                                            <p>
+                                                <span className="font-medium text-foreground">
+                                                    Location:
+                                                </span>{" "}
+                                                {work.location}
+                                            </p>
+                                        )}
+                                    </div>
+
+                                    {work.publisher && (
+                                        <div className="mt-3 pt-3 border-t text-xs text-muted-foreground">
+                                            <p>Publisher: {work.publisher}</p>
+                                        </div>
+                                    )}
+                                </Link>
+                            ))}
+                        </div>
+                    )}
+
+                    {/* ====== LIST VIEW ====== */}
+                    {viewMode === "list" && (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>
+                                        <button
+                                            className="flex items-center font-medium hover:text-foreground transition-colors"
+                                            onClick={() =>
+                                                handleColumnSort("title")
+                                            }
+                                        >
+                                            Title
+                                            {renderSortIcon("title")}
+                                        </button>
+                                    </TableHead>
+                                    <TableHead>
+                                        <button
+                                            className="flex items-center font-medium hover:text-foreground transition-colors"
+                                            onClick={() =>
+                                                handleColumnSort("call_number")
+                                            }
+                                        >
+                                            Call Number
+                                            {renderSortIcon("call_number")}
+                                        </button>
+                                    </TableHead>
+                                    <TableHead>
+                                        <button
+                                            className="flex items-center font-medium hover:text-foreground transition-colors"
+                                            onClick={() =>
+                                                handleColumnSort(
+                                                    "date_published"
+                                                )
+                                            }
+                                        >
+                                            Published
+                                            {renderSortIcon("date_published")}
+                                        </button>
+                                    </TableHead>
+                                    <TableHead>
+                                        <button
+                                            className="flex items-center font-medium hover:text-foreground transition-colors"
+                                            onClick={() =>
+                                                handleColumnSort("media_type")
+                                            }
+                                        >
+                                            Type
+                                            {renderSortIcon("media_type")}
+                                        </button>
+                                    </TableHead>
+                                    <TableHead>Language</TableHead>
+                                    <TableHead>
+                                        <button
+                                            className="flex items-center font-medium hover:text-foreground transition-colors"
+                                            onClick={() =>
+                                                handleColumnSort(
+                                                    "number_of_pages"
+                                                )
+                                            }
+                                        >
+                                            Pages
+                                            {renderSortIcon("number_of_pages")}
+                                        </button>
+                                    </TableHead>
+                                    <TableHead>Publisher</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {processedResults.map((work) => (
+                                    <TableRow
+                                        key={work.id}
+                                        className="cursor-pointer hover:bg-muted/50"
+                                        onClick={() => router.push(`/works/${work.id}`)}
+                                    >
+                                        <TableCell className="font-medium max-w-[280px] truncate">
+                                            {work.title}
+                                        </TableCell>
+                                        <TableCell>
+                                            {work.call_number ?? "—"}
+                                        </TableCell>
+                                        <TableCell>
+                                            {work.date_published
+                                                ? extractYear(work.date_published)
+                                                : "—"}
+                                        </TableCell>
+                                        <TableCell>
+                                            {work.media_type ? (
+                                                <Badge variant="secondary">
+                                                    {work.media_type
+                                                        .charAt(0)
+                                                        .toUpperCase() +
+                                                        work.media_type.slice(
+                                                            1
+                                                        )}
+                                                </Badge>
+                                            ) : (
+                                                "—"
+                                            )}
+                                        </TableCell>
+                                        <TableCell>
+                                            {work.language ?? "—"}
+                                        </TableCell>
+                                        <TableCell>
+                                            {work.number_of_pages ?? "—"}
+                                        </TableCell>
+                                        <TableCell className="text-xs">
+                                            {work.publisher ?? "—"}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    )}
                 </>
             )}
         </div>

--- a/src/app/staff/staff-checkouts-client.tsx
+++ b/src/app/staff/staff-checkouts-client.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Search } from "lucide-react";
 import { CheckoutFormDialog } from "./checkout-form-dialog";
 import { ReturnCheckoutDialog } from "./return-checkout-dialog";
 
@@ -108,13 +109,16 @@ export function StaffCheckoutsClient({
     <div className="space-y-4">
       <div className="flex items-center gap-4">
         <Button onClick={() => setFormOpen(true)}>Check Out Item</Button>
-        <Input
-          id="checkout-search"
-          placeholder="Search by title, name, or email..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="max-w-sm"
-        />
+        <div className="relative max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            id="checkout-search"
+            placeholder="Search by title, name, or email..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
         <Select name="status-filter" value={statusFilter} onValueChange={setStatusFilter}>
           <SelectTrigger id="status-filter" className="w-[160px]">
             <SelectValue placeholder="Filter status" />

--- a/src/app/staff/staff-works-client.tsx
+++ b/src/app/staff/staff-works-client.tsx
@@ -25,6 +25,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Search } from "lucide-react";
 import { WorkFormDialog } from "./work-form-dialog";
 import { DeleteWorkDialog } from "./delete-work-dialog";
 
@@ -107,13 +108,16 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
         <div className="space-y-4">
             <div className="flex items-center gap-4">
                 <Button onClick={openAddDialog}>Add Work</Button>
-                <Input
-                    id="works-search"
-                    placeholder="Search by title or publisher..."
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    className="max-w-sm"
-                />
+                <div className="relative max-w-sm">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                    <Input
+                        id="works-search"
+                        placeholder="Search by title or publisher..."
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        className="pl-9"
+                    />
+                </div>
                 <Select name="media-filter" value={mediaFilter} onValueChange={setMediaFilter}>
                     <SelectTrigger id="media-filter" className="w-[160px]">
                         <SelectValue placeholder="Filter media type" />

--- a/src/lib/data/works.ts
+++ b/src/lib/data/works.ts
@@ -111,6 +111,21 @@ export async function getWorkById(id: string): Promise<WorkWithCoverDTO | null> 
     return result.rows[0] as WorkWithCoverDTO;
 }
 
+/** Get a single work by ID (public access). Includes base64-encoded cover. */
+export async function getPublicWorkById(id: string): Promise<WorkWithCoverDTO | null> {
+    const result = await query(
+        `SELECT id, created_at, title, date_published, publisher,
+                encode(cover, 'base64') as cover,
+                editor, lccn, isbn_10, isbn_13, media_type, number_of_pages,
+                language, location, call_number, updated_at
+         FROM works WHERE id = $1`,
+        [id]
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0] as WorkWithCoverDTO;
+}
+
 /** Search works (public). Returns DTOs without cover data. */
 export async function searchWorks(params: {
     q?: string;


### PR DESCRIPTION
- Create public query layer to allow fetching work details without staff authentication
- Add a new route for the public book details view with a Goodreads-style layout
- Display book cover and all metadata fields, including a fallback for missing covers
- Make search results clickable to route directly to the new book details page
- Handle asynchronous URL parameters resolution properly
- Refine layout by grouping and reducing visual prominence of ISBN and LCCN fields
- Add an 'Edit Work' button available only to staff/admin on the public details page, leveraging the existing form dialog for seamless inline editing
- Add respective unit tests for the public data access layer