### PR TITLE
U24-request-extension: add book extensions and quick returns from work page

### DIFF
--- a/src/__tests__/lib/data/checkouts.test.ts
+++ b/src/__tests__/lib/data/checkouts.test.ts
@@ -23,6 +23,11 @@ import {
     returnCheckout,
     getCheckoutsNeedingReminders,
     markReminderSent,
+    getUserCheckouts,
+    requestCheckoutExtension,
+    approveCheckoutExtension,
+    rejectCheckoutExtension,
+    getActiveCheckoutForWork,
 } from "@/lib/data/checkouts";
 
 const staffUser = {
@@ -301,6 +306,118 @@ describe("markReminderSent", () => {
 
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("UPDATE checkouts SET reminder_sent_at"),
+            ["c1"]
+        );
+    });
+});
+
+// ─── getUserCheckouts ───────────────────────────────────────────────
+
+describe("getUserCheckouts", () => {
+    it("returns user checkouts with joined data", async () => {
+        const checkouts = [
+            { id: "c1", work_title: "Book A", user_name: "Alice" },
+        ];
+        mockQuery.mockResolvedValue({ rows: checkouts });
+
+        const result = await getUserCheckouts("u1");
+
+        expect(result).toEqual(checkouts);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("WHERE c.user_id = $1"),
+            ["u1"]
+        );
+    });
+});
+
+// ─── getActiveCheckoutForWork ───────────────────────────────────────
+
+describe("getActiveCheckoutForWork", () => {
+    it("returns checkout id if active", async () => {
+        mockQuery.mockResolvedValue({ rows: [{ id: "c1" }] });
+        const result = await getActiveCheckoutForWork("w1");
+        expect(result).toBe("c1");
+    });
+
+    it("returns null if no active checkout", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+        const result = await getActiveCheckoutForWork("w1");
+        expect(result).toBeNull();
+    });
+});
+
+// ─── requestCheckoutExtension ───────────────────────────────────────
+
+describe("requestCheckoutExtension", () => {
+    it("updates extension_status to pending", async () => {
+        const updatedCheckout = { id: "c1", extension_status: "pending" };
+        mockQuery.mockResolvedValue({ rows: [updatedCheckout] });
+
+        const result = await requestCheckoutExtension("c1", "u1");
+
+        expect(result).toEqual(updatedCheckout);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("UPDATE checkouts SET extension_status = 'pending'"),
+            ["c1", "u1"]
+        );
+    });
+
+    it("returns null when checkout not found or ineligible", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+        const result = await requestCheckoutExtension("c999", "u1");
+        expect(result).toBeNull();
+    });
+});
+
+// ─── approveCheckoutExtension ───────────────────────────────────────
+
+describe("approveCheckoutExtension", () => {
+    it("throws Unauthorized when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        await expect(approveCheckoutExtension("c1")).rejects.toThrow("Unauthorized");
+    });
+
+    it("throws Forbidden when role is user", async () => {
+        mockGetCurrentUser.mockResolvedValue(regularUser);
+        await expect(approveCheckoutExtension("c1")).rejects.toThrow("Forbidden");
+    });
+
+    it("updates extension_status to approved and due_date", async () => {
+        const updatedCheckout = { id: "c1", extension_status: "approved" };
+        mockQuery.mockResolvedValue({ rows: [updatedCheckout] });
+
+        const result = await approveCheckoutExtension("c1");
+
+        expect(result).toEqual(updatedCheckout);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("due_date = due_date + interval '14 days'"),
+            ["c1"]
+        );
+    });
+});
+
+// ─── rejectCheckoutExtension ────────────────────────────────────────
+
+describe("rejectCheckoutExtension", () => {
+    it("throws Unauthorized when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        await expect(rejectCheckoutExtension("c1")).rejects.toThrow("Unauthorized");
+    });
+
+    it("throws Forbidden when role is user", async () => {
+        mockGetCurrentUser.mockResolvedValue(regularUser);
+        await expect(rejectCheckoutExtension("c1")).rejects.toThrow("Forbidden");
+    });
+
+    it("updates extension_status to rejected", async () => {
+        const updatedCheckout = { id: "c1", extension_status: "rejected" };
+        mockQuery.mockResolvedValue({ rows: [updatedCheckout] });
+
+        const result = await rejectCheckoutExtension("c1");
+
+        expect(result).toEqual(updatedCheckout);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("extension_status = 'rejected'"),
             ["c1"]
         );
     });

--- a/src/app/staff/staff-checkouts-client.tsx
+++ b/src/app/staff/staff-checkouts-client.tsx
@@ -34,6 +34,7 @@ interface Checkout {
   work_title: string;
   user_name: string;
   user_email: string;
+  extension_status?: "none" | "pending" | "approved" | "rejected";
 }
 
 interface Work {
@@ -71,6 +72,24 @@ export function StaffCheckoutsClient({
   const [returningCheckout, setReturningCheckout] = useState<Checkout | null>(
     null,
   );
+  const [loadingExtensionId, setLoadingExtensionId] = useState<string | null>(null);
+
+  const handleExtension = async (id: string, action: 'approve' | 'reject') => {
+    setLoadingExtensionId(id);
+    try {
+      const res = await fetch(`/api/staff/checkouts/${id}/extend/${action}`, { method: 'POST' });
+      if (res.ok) {
+        router.refresh();
+      } else {
+        const data = await res.json();
+        alert(data.error || `Failed to ${action} extension`);
+      }
+    } catch (e: any) {
+      alert(e.message);
+    } finally {
+      setLoadingExtensionId(null);
+    }
+  };
 
   const checkedOutWorkIds = useMemo(() => {
     const ids = new Set<string>();
@@ -191,24 +210,53 @@ export function StaffCheckoutsClient({
                   </TableCell>
                 )}
                 <TableCell>
-                  {checkout.returned_at ? (
-                    <Badge variant="secondary">Returned</Badge>
-                  ) : isOverdue(checkout) ? (
-                    <Badge variant="destructive">Overdue</Badge>
-                  ) : (
-                    <Badge>Active</Badge>
-                  )}
+                  <div className="flex flex-col gap-1 items-start">
+                    {checkout.returned_at ? (
+                      <Badge variant="secondary">Returned</Badge>
+                    ) : isOverdue(checkout) ? (
+                      <Badge variant="destructive">Overdue</Badge>
+                    ) : (
+                      <Badge>Active</Badge>
+                    )}
+                    {checkout.extension_status === 'pending' && (
+                      <Badge variant="outline" className="text-yellow-600 border-yellow-600 dark:text-yellow-500 dark:border-yellow-500">
+                        Ext. pending
+                      </Badge>
+                    )}
+                  </div>
                 </TableCell>
                 <TableCell onClick={(e) => e.stopPropagation()}>
-                  {!checkout.returned_at && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => openReturnDialog(checkout)}
-                    >
-                      Return
-                    </Button>
-                  )}
+                  <div className="flex flex-wrap gap-2">
+                    {!checkout.returned_at && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => openReturnDialog(checkout)}
+                      >
+                        Return
+                      </Button>
+                    )}
+                    {checkout.extension_status === 'pending' && (
+                      <>
+                        <Button
+                          variant="default"
+                          size="sm"
+                          disabled={loadingExtensionId === checkout.id}
+                          onClick={() => handleExtension(checkout.id, 'approve')}
+                        >
+                          Approve Ext
+                        </Button>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          disabled={loadingExtensionId === checkout.id}
+                          onClick={() => handleExtension(checkout.id, 'reject')}
+                        >
+                          Reject
+                        </Button>
+                      </>
+                    )}
+                  </div>
                 </TableCell>
               </TableRow>
             ))

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -28,7 +28,10 @@ export async function Header() {
                   <Link href="/staff">Staff</Link>
                 </Button>
               )}
-              <span className="text-sm text-muted-foreground">
+              <Button variant="ghost" size="sm" asChild>
+                <Link href="/profile">My Profile</Link>
+              </Button>
+              <span className="text-sm text-muted-foreground ml-2">
                 {user.name}
               </span>
               <LogoutButton />

--- a/src/lib/data/checkouts.ts
+++ b/src/lib/data/checkouts.ts
@@ -15,6 +15,7 @@ export interface CheckoutDTO {
     due_date: string;
     returned_at: string | null;
     reminder_sent_at: string | null;
+    extension_status: "none" | "pending" | "approved" | "rejected";
     created_at: string;
     updated_at: string;
     work_title: string;
@@ -30,6 +31,7 @@ export interface CheckoutBaseDTO {
     due_date: string;
     returned_at: string | null;
     reminder_sent_at: string | null;
+    extension_status: "none" | "pending" | "approved" | "rejected";
     created_at: string;
     updated_at: string;
 }
@@ -59,7 +61,7 @@ export async function getAllCheckouts(): Promise<CheckoutDTO[]> {
 
     const result = await query(
         `SELECT c.id, c.work_id, c.user_id, c.checked_out_at, c.due_date,
-                c.returned_at, c.reminder_sent_at, c.created_at, c.updated_at,
+                c.returned_at, c.reminder_sent_at, c.extension_status, c.created_at, c.updated_at,
                 w.title AS work_title,
                 u.name AS user_name, u.email AS user_email
          FROM checkouts c
@@ -79,7 +81,7 @@ export async function getCheckoutById(
 
     const result = await query(
         `SELECT c.id, c.work_id, c.user_id, c.checked_out_at, c.due_date,
-                c.returned_at, c.reminder_sent_at, c.created_at, c.updated_at,
+                c.returned_at, c.reminder_sent_at, c.extension_status, c.created_at, c.updated_at,
                 w.title AS work_title,
                 u.name AS user_name, u.email AS user_email
          FROM checkouts c
@@ -93,6 +95,24 @@ export async function getCheckoutById(
     return result.rows[0] as CheckoutDTO;
 }
 
+/** Get all checkouts for a given user ID.  */
+export async function getUserCheckouts(userId: string): Promise<CheckoutDTO[]> {
+    const result = await query(
+        `SELECT c.id, c.work_id, c.user_id, c.checked_out_at, c.due_date,
+                c.returned_at, c.reminder_sent_at, c.extension_status, c.created_at, c.updated_at,
+                w.title AS work_title,
+                u.name AS user_name, u.email AS user_email
+         FROM checkouts c
+         JOIN works w ON w.id = c.work_id
+         JOIN users u ON u.id = c.user_id
+         WHERE c.user_id = $1
+         ORDER BY c.created_at DESC`,
+        [userId]
+    );
+
+    return result.rows as CheckoutDTO[];
+}
+
 /** Check if a specific work is currently checked out. Return true if checked out. */
 export async function isWorkCheckedOut(workId: string): Promise<boolean> {
     await requireStaffUser();
@@ -103,6 +123,21 @@ export async function isWorkCheckedOut(workId: string): Promise<boolean> {
     );
 
     return activeCheckout.rows.length > 0;
+}
+
+/** Get the active (not returned) checkout ID for a specific work, if any. Return null if none. */
+export async function getActiveCheckoutForWork(
+    workId: string
+): Promise<string | null> {
+    await requireStaffUser();
+
+    const activeCheckout = await query(
+        "SELECT id FROM checkouts WHERE work_id = $1 AND returned_at IS NULL",
+        [workId]
+    );
+
+    if (activeCheckout.rows.length === 0) return null;
+    return activeCheckout.rows[0].id as string;
 }
 
 // ---------------------------------------------------------------------------
@@ -150,7 +185,7 @@ export async function createCheckout(input: {
         `INSERT INTO checkouts (work_id, user_id, due_date)
          VALUES ($1, $2, $3)
          RETURNING id, work_id, user_id, checked_out_at, due_date, returned_at,
-                   reminder_sent_at, created_at, updated_at`,
+                   reminder_sent_at, extension_status, created_at, updated_at`,
         [input.work_id, input.user_id, input.due_date]
     );
 
@@ -170,7 +205,7 @@ export async function returnCheckout(
         `UPDATE checkouts SET returned_at = NOW(), updated_at = NOW()
          WHERE id = $1 AND returned_at IS NULL
          RETURNING id, work_id, user_id, checked_out_at, due_date, returned_at,
-                   reminder_sent_at, created_at, updated_at`,
+                   reminder_sent_at, extension_status, created_at, updated_at`,
         [id]
     );
 
@@ -186,7 +221,7 @@ export async function getCheckoutsNeedingReminders(
 ): Promise<CheckoutDTO[]> {
     const result = await query(
         `SELECT c.id, c.work_id, c.user_id, c.checked_out_at, c.due_date,
-                c.returned_at, c.reminder_sent_at, c.created_at, c.updated_at,
+                c.returned_at, c.reminder_sent_at, c.extension_status, c.created_at, c.updated_at,
                 w.title AS work_title,
                 u.name AS user_name, u.email AS user_email
          FROM checkouts c
@@ -210,4 +245,71 @@ export async function markReminderSent(id: string): Promise<void> {
          WHERE id = $1`,
         [id]
     );
+}
+
+/**
+ * Request an extension for a checkout (User only).
+ * Requires the checkout to be active (not returned) and for it to belong to the user.
+ */
+export async function requestCheckoutExtension(
+    id: string,
+    userId: string
+): Promise<CheckoutBaseDTO | null> {
+    const result = await query(
+        `UPDATE checkouts SET extension_status = 'pending', updated_at = NOW()
+         WHERE id = $1 AND user_id = $2 AND returned_at IS NULL AND extension_status = 'none'
+         RETURNING id, work_id, user_id, checked_out_at, due_date, returned_at,
+                   reminder_sent_at, extension_status, created_at, updated_at`,
+        [id, userId]
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0] as CheckoutBaseDTO;
+}
+
+/**
+ * Approve a checkout extension (Staff only).
+ * Adds 14 days to the due_date and marks status as 'approved'.
+ */
+export async function approveCheckoutExtension(
+    id: string
+): Promise<CheckoutBaseDTO | null> {
+    await requireStaffUser();
+
+    const result = await query(
+        `UPDATE checkouts 
+         SET due_date = due_date + interval '14 days',
+             extension_status = 'approved',
+             updated_at = NOW()
+         WHERE id = $1 AND returned_at IS NULL AND extension_status = 'pending'
+         RETURNING id, work_id, user_id, checked_out_at, due_date, returned_at,
+                   reminder_sent_at, extension_status, created_at, updated_at`,
+        [id]
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0] as CheckoutBaseDTO;
+}
+
+/**
+ * Reject a checkout extension (Staff only).
+ * Marks status as 'rejected'.
+ */
+export async function rejectCheckoutExtension(
+    id: string
+): Promise<CheckoutBaseDTO | null> {
+    await requireStaffUser();
+
+    const result = await query(
+        `UPDATE checkouts 
+         SET extension_status = 'rejected',
+             updated_at = NOW()
+         WHERE id = $1 AND returned_at IS NULL AND extension_status = 'pending'
+         RETURNING id, work_id, user_id, checked_out_at, due_date, returned_at,
+                   reminder_sent_at, extension_status, created_at, updated_at`,
+        [id]
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0] as CheckoutBaseDTO;
 }


### PR DESCRIPTION
Introduces two major features for managing book checkouts:

Book Extensions
Add extension_status to checkouts table.
Create secure API endpoints for requesting, approving, and rejecting extensions. Add /profile page for users to view checkouts and request extensions. Update staff checkouts dashboard to show pending extensions and approve/reject actions. Quick Returns from Work Page
Add Return Book button to works/[id] page, visible only to Staff/Admins when a book is checked out. Unify return confirmation UI to use ReturnCheckoutDialog instead of browser confirm(). Includes comprehensive DAL unit tests and successful production build verification.