### PR TITLE
Apply Karson Institute brand colors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,37 +47,37 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --background: #F2F2F2;
+  --foreground: #000000;
+  --card: #FFFFFF;
+  --card-foreground: #000000;
+  --popover: #FFFFFF;
+  --popover-foreground: #000000;
+  --primary: #0D4B34;
+  --primary-foreground: #FFFFFF;
   --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
+  --secondary-foreground: #000000;
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --accent: #E8F5EF;
+  --accent-foreground: #0D4B34;
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
+  --border: #C8C8C8;
+  --input: #C8C8C8;
+  --ring: #006242;
+  --chart-1: #0D4B34;
+  --chart-2: #006242;
+  --chart-3: #209765;
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: #FFFFFF;
+  --sidebar-foreground: #000000;
+  --sidebar-primary: #0D4B34;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #E8F5EF;
+  --sidebar-accent-foreground: #0D4B34;
+  --sidebar-border: #C8C8C8;
+  --sidebar-ring: #006242;
 }
 
 .dark {

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -7,10 +7,10 @@ export async function Header() {
   const user = await getCurrentUser();
 
   return (
-    <header className="border-b">
+    <header className="bg-primary text-primary-foreground">
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4">
         <div className="flex items-center gap-4">
-          <Link href="/" className="text-lg font-semibold">
+          <Link href="/" className="text-lg font-semibold text-primary-foreground">
             Home
           </Link>
         </div>
@@ -19,25 +19,25 @@ export async function Header() {
           {user ? (
             <>
               {user.role === "admin" && (
-                <Button variant="ghost" size="sm" asChild>
+                <Button variant="ghost" size="sm" className="text-primary-foreground hover:bg-white/15 hover:text-primary-foreground" asChild>
                   <Link href="/admin">Admin</Link>
                 </Button>
               )}
               {(user.role === "admin" || user.role === "staff") && (
-                <Button variant="ghost" size="sm" asChild>
+                <Button variant="ghost" size="sm" className="text-primary-foreground hover:bg-white/15 hover:text-primary-foreground" asChild>
                   <Link href="/staff">Staff</Link>
                 </Button>
               )}
-              <Button variant="ghost" size="sm" asChild>
+              <Button variant="ghost" size="sm" className="text-primary-foreground hover:bg-white/15 hover:text-primary-foreground" asChild>
                 <Link href="/profile">My Profile</Link>
               </Button>
-              <span className="text-sm text-muted-foreground ml-2">
+              <span className="text-sm text-primary-foreground/70 ml-2">
                 {user.name}
               </span>
               <LogoutButton />
             </>
           ) : (
-            <Button variant="ghost" size="sm" asChild>
+            <Button variant="ghost" size="sm" className="text-primary-foreground hover:bg-white/15 hover:text-primary-foreground" asChild>
               <Link href="/login">Sign In</Link>
             </Button>
           )}


### PR DESCRIPTION
## Summary
- Remap CSS custom properties in `globals.css` to use Karson Institute brand palette (Dark Spruce, Evergreen, Go Green, Andrew White)
- Style the header with dark green background and white text for strong brand presence
- All ShadCN components automatically pick up the new colors via CSS variables

## Test plan
- [x] All 282 tests pass
- [ ] Visually confirm header is dark green with white text
- [ ] Visually confirm primary buttons are green, page background is off-white, cards are white
- [ ] Visually confirm focus rings are green and hover states use brand colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)