### PR TITLE
feat: add hold system for works

### DIFF
--- a/src/__tests__/api/works/hold.test.ts
+++ b/src/__tests__/api/works/hold.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @jest-environment node
+ */
+
+const mockGetCurrentUser = jest.fn();
+jest.mock("@/lib/auth", () => ({
+    getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+jest.mock("next/headers", () => ({
+    cookies: jest.fn(),
+}));
+
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({
+    query: (text: string, params?: unknown[]) => mockQuery(text, params),
+}));
+
+import { GET, POST, DELETE } from "@/app/api/works/[id]/hold/route";
+import { NextRequest } from "next/server";
+
+const regularUser = {
+    id: "user-1",
+    email: "user@example.com",
+    name: "User",
+    role: "user",
+};
+
+function makeParams(id: string) {
+    return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue(regularUser);
+});
+
+// ─── GET /api/works/[id]/hold ─────────────────────────────────────
+
+describe("GET /api/works/[id]/hold", () => {
+    it("returns hold when it exists", async () => {
+        const hold = {
+            id: "h1",
+            work_id: "w1",
+            user_id: "user-1",
+            user_name: "User",
+            created_at: "2026-01-01",
+        };
+        mockQuery.mockResolvedValue({ rows: [hold] });
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "GET" }
+        );
+        const res = await GET(req, makeParams("w1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.hold).toEqual(hold);
+    });
+
+    it("returns null when no hold exists", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "GET" }
+        );
+        const res = await GET(req, makeParams("w1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.hold).toBeNull();
+    });
+});
+
+// ─── POST /api/works/[id]/hold ────────────────────────────────────
+
+describe("POST /api/works/[id]/hold", () => {
+    it("returns 401 when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "POST" }
+        );
+        const res = await POST(req, makeParams("w1"));
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 404 when work not found", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // work lookup
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "POST" }
+        );
+        const res = await POST(req, makeParams("w1"));
+        expect(res.status).toBe(404);
+    });
+
+    it("returns 409 when work is already on hold", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "w1" }] }); // work exists
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "h1" }] }); // existing hold
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "POST" }
+        );
+        const res = await POST(req, makeParams("w1"));
+        expect(res.status).toBe(409);
+    });
+
+    it("returns 409 when user already has a hold", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "w1" }] }); // work exists
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // no hold on work
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "h2" }] }); // user has hold
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "POST" }
+        );
+        const res = await POST(req, makeParams("w1"));
+        expect(res.status).toBe(409);
+    });
+
+    it("creates a hold successfully", async () => {
+        const newHold = {
+            id: "h1",
+            work_id: "w1",
+            user_id: "user-1",
+            created_at: "2026-01-01",
+        };
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "w1" }] }); // work exists
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // no hold on work
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // user has no hold
+        mockQuery.mockResolvedValueOnce({ rows: [newHold] }); // insert
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "POST" }
+        );
+        const res = await POST(req, makeParams("w1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(201);
+        expect(body.hold).toEqual({
+            ...newHold,
+            user_name: "User",
+        });
+    });
+
+    it("returns 500 on unexpected error", async () => {
+        mockGetCurrentUser.mockRejectedValue("unexpected");
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "POST" }
+        );
+        const res = await POST(req, makeParams("w1"));
+        expect(res.status).toBe(500);
+    });
+});
+
+// ─── DELETE /api/works/[id]/hold ──────────────────────────────────
+
+describe("DELETE /api/works/[id]/hold", () => {
+    it("returns 401 when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "DELETE" }
+        );
+        const res = await DELETE(req, makeParams("w1"));
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 404 when hold not found", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // hold lookup
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "DELETE" }
+        );
+        const res = await DELETE(req, makeParams("w1"));
+        expect(res.status).toBe(404);
+    });
+
+    it("returns 403 when user is not owner and not staff", async () => {
+        const otherUser = { ...regularUser, id: "user-2" };
+        mockGetCurrentUser.mockResolvedValue(otherUser);
+        mockQuery.mockResolvedValueOnce({
+            rows: [{ id: "h1", user_id: "user-1" }],
+        }); // hold belongs to user-1
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "DELETE" }
+        );
+        const res = await DELETE(req, makeParams("w1"));
+        expect(res.status).toBe(403);
+    });
+
+    it("returns 204 when hold is deleted by owner", async () => {
+        mockQuery.mockResolvedValueOnce({
+            rows: [{ id: "h1", user_id: "user-1" }],
+        }); // hold lookup
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // delete
+
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "DELETE" }
+        );
+        const res = await DELETE(req, makeParams("w1"));
+
+        expect(res.status).toBe(204);
+    });
+
+    it("returns 500 on unexpected error", async () => {
+        mockGetCurrentUser.mockRejectedValue("unexpected");
+        const req = new NextRequest(
+            "http://localhost:3000/api/works/w1/hold",
+            { method: "DELETE" }
+        );
+        const res = await DELETE(req, makeParams("w1"));
+        expect(res.status).toBe(500);
+    });
+});

--- a/src/__tests__/lib/data/checkouts.test.ts
+++ b/src/__tests__/lib/data/checkouts.test.ts
@@ -212,14 +212,39 @@ describe("createCheckout", () => {
         mockQuery.mockResolvedValueOnce({ rows: [{ id: "u1" }] }); // user exists
         mockQuery.mockResolvedValueOnce({ rows: [] }); // no active checkout
         mockQuery.mockResolvedValueOnce({ rows: [newCheckout] }); // insert
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // delete holds
 
         const result = await createCheckout(validInput);
 
         expect(result).toEqual(newCheckout);
-        expect(mockQuery).toHaveBeenCalledTimes(4);
-        expect(mockQuery).toHaveBeenLastCalledWith(
+        expect(mockQuery).toHaveBeenCalledTimes(5);
+        expect(mockQuery).toHaveBeenNthCalledWith(
+            4,
             expect.stringContaining("INSERT"),
             ["w1", "u1", "2026-03-01"]
+        );
+    });
+
+    it("removes hold on work after successful checkout", async () => {
+        const newCheckout = {
+            id: "c1",
+            work_id: "w1",
+            user_id: "u1",
+            due_date: "2026-03-01",
+            returned_at: null,
+        };
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "w1" }] }); // work exists
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "u1" }] }); // user exists
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // no active checkout
+        mockQuery.mockResolvedValueOnce({ rows: [newCheckout] }); // insert
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // delete holds
+
+        await createCheckout(validInput);
+
+        expect(mockQuery).toHaveBeenNthCalledWith(
+            5,
+            expect.stringContaining("DELETE FROM holds WHERE work_id = $1"),
+            ["w1"]
         );
     });
 
@@ -230,6 +255,7 @@ describe("createCheckout", () => {
         mockQuery.mockResolvedValueOnce({ rows: [{ id: "u1" }] });
         mockQuery.mockResolvedValueOnce({ rows: [] });
         mockQuery.mockResolvedValueOnce({ rows: [newCheckout] });
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // delete holds
 
         const result = await createCheckout(validInput);
 

--- a/src/__tests__/lib/data/holds.test.ts
+++ b/src/__tests__/lib/data/holds.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @jest-environment node
+ */
+
+const mockGetCurrentUser = jest.fn();
+jest.mock("@/lib/auth", () => ({
+    getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+jest.mock("next/headers", () => ({
+    cookies: jest.fn(),
+}));
+
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({
+    query: (text: string, params?: unknown[]) => mockQuery(text, params),
+}));
+
+import {
+    getHoldForWork,
+    createHold,
+    deleteHold,
+} from "@/lib/data/holds";
+
+const regularUser = {
+    id: "user-1",
+    email: "user@example.com",
+    name: "User",
+    role: "user",
+};
+
+const staffUser = {
+    id: "staff-1",
+    email: "staff@example.com",
+    name: "Staff",
+    role: "staff",
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue(regularUser);
+});
+
+// ─── getHoldForWork ──────────────────────────────────────────────
+
+describe("getHoldForWork", () => {
+    it("returns hold when it exists", async () => {
+        const hold = {
+            id: "h1",
+            work_id: "w1",
+            user_id: "user-1",
+            user_name: "User",
+            created_at: "2026-01-01",
+        };
+        mockQuery.mockResolvedValue({ rows: [hold] });
+
+        const result = await getHoldForWork("w1");
+
+        expect(result).toEqual(hold);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("WHERE h.work_id = $1"),
+            ["w1"]
+        );
+    });
+
+    it("returns null when no hold exists", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        const result = await getHoldForWork("w1");
+
+        expect(result).toBeNull();
+    });
+
+    it("joins users table for user_name", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        await getHoldForWork("w1");
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("JOIN users"),
+            ["w1"]
+        );
+    });
+});
+
+// ─── createHold ──────────────────────────────────────────────────
+
+describe("createHold", () => {
+    it("throws Unauthorized when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        await expect(createHold("w1")).rejects.toThrow("Unauthorized");
+    });
+
+    it("throws when work does not exist", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // work lookup
+
+        await expect(createHold("w1")).rejects.toThrow("Work not found");
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws when work is already on hold", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "w1" }] }); // work exists
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "h1" }] }); // existing hold
+
+        await expect(createHold("w1")).rejects.toThrow(
+            "This work is already on hold"
+        );
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws when user already has a hold", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "w1" }] }); // work exists
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // no hold on work
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "h2" }] }); // user has hold
+
+        await expect(createHold("w1")).rejects.toThrow(
+            "You already have a work on hold"
+        );
+        expect(mockQuery).toHaveBeenCalledTimes(3);
+    });
+
+    it("creates a hold successfully", async () => {
+        const newHold = {
+            id: "h1",
+            work_id: "w1",
+            user_id: "user-1",
+            created_at: "2026-01-01",
+        };
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: "w1" }] }); // work exists
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // no hold on work
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // user has no hold
+        mockQuery.mockResolvedValueOnce({ rows: [newHold] }); // insert
+
+        const result = await createHold("w1");
+
+        expect(result).toEqual({
+            ...newHold,
+            user_name: "User",
+        });
+        expect(mockQuery).toHaveBeenCalledTimes(4);
+        expect(mockQuery).toHaveBeenLastCalledWith(
+            expect.stringContaining("INSERT INTO holds"),
+            ["w1", "user-1"]
+        );
+    });
+});
+
+// ─── deleteHold ──────────────────────────────────────────────────
+
+describe("deleteHold", () => {
+    it("throws Unauthorized when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        await expect(deleteHold("w1")).rejects.toThrow("Unauthorized");
+    });
+
+    it("throws when hold not found", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // hold lookup
+
+        await expect(deleteHold("w1")).rejects.toThrow("Hold not found");
+    });
+
+    it("throws Forbidden when user is not owner and not staff", async () => {
+        const otherUser = { ...regularUser, id: "user-2" };
+        mockGetCurrentUser.mockResolvedValue(otherUser);
+        mockQuery.mockResolvedValueOnce({
+            rows: [{ id: "h1", user_id: "user-1" }],
+        }); // hold belongs to user-1
+
+        await expect(deleteHold("w1")).rejects.toThrow("Forbidden");
+    });
+
+    it("allows owner to delete their hold", async () => {
+        mockQuery.mockResolvedValueOnce({
+            rows: [{ id: "h1", user_id: "user-1" }],
+        }); // hold lookup
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // delete
+
+        await expect(deleteHold("w1")).resolves.toBeUndefined();
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+        expect(mockQuery).toHaveBeenLastCalledWith(
+            expect.stringContaining("DELETE FROM holds"),
+            ["h1"]
+        );
+    });
+
+    it("allows staff to delete any hold", async () => {
+        mockGetCurrentUser.mockResolvedValue(staffUser);
+        mockQuery.mockResolvedValueOnce({
+            rows: [{ id: "h1", user_id: "user-1" }],
+        }); // hold belongs to another user
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // delete
+
+        await expect(deleteHold("w1")).resolves.toBeUndefined();
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/app/api/works/[id]/hold/route.ts
+++ b/src/app/api/works/[id]/hold/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+    getHoldForWork,
+    createHold,
+    deleteHold,
+} from "@/lib/data/holds";
+
+interface RouteContext {
+    params: Promise<{ id: string }>;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+    try {
+        const { id } = await context.params;
+        const hold = await getHoldForWork(id);
+        return NextResponse.json({ hold });
+    } catch (error) {
+        const message =
+            error instanceof Error ? error.message : "Internal server error";
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+    try {
+        const { id } = await context.params;
+        const hold = await createHold(id);
+        return NextResponse.json({ hold }, { status: 201 });
+    } catch (error) {
+        const message =
+            error instanceof Error ? error.message : "Internal server error";
+        if (message === "Unauthorized") {
+            return NextResponse.json({ error: message }, { status: 401 });
+        }
+        if (message === "Work not found") {
+            return NextResponse.json({ error: message }, { status: 404 });
+        }
+        if (
+            message === "This work is already on hold" ||
+            message === "You already have a work on hold"
+        ) {
+            return NextResponse.json({ error: message }, { status: 409 });
+        }
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+    try {
+        const { id } = await context.params;
+        await deleteHold(id);
+        return new NextResponse(null, { status: 204 });
+    } catch (error) {
+        const message =
+            error instanceof Error ? error.message : "Internal server error";
+        if (message === "Unauthorized") {
+            return NextResponse.json({ error: message }, { status: 401 });
+        }
+        if (message === "Forbidden") {
+            return NextResponse.json({ error: message }, { status: 403 });
+        }
+        if (message === "Hold not found") {
+            return NextResponse.json({ error: message }, { status: 404 });
+        }
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}

--- a/src/app/works/[id]/hold-work-button.tsx
+++ b/src/app/works/[id]/hold-work-button.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Hand } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export interface HoldWorkButtonProps {
+    workId: string;
+    holdStatus: "none" | "own" | "other";
+    holdUserName?: string;
+}
+
+export function HoldWorkButton({ workId, holdStatus, holdUserName }: HoldWorkButtonProps) {
+    const [loading, setLoading] = useState(false);
+    const router = useRouter();
+
+    const handleRequestHold = async () => {
+        setLoading(true);
+        try {
+            const res = await fetch(`/api/works/${workId}/hold`, {
+                method: "POST",
+            });
+            if (res.ok) {
+                router.refresh();
+            }
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleRemoveHold = async () => {
+        setLoading(true);
+        try {
+            const res = await fetch(`/api/works/${workId}/hold`, {
+                method: "DELETE",
+            });
+            if (res.ok) {
+                router.refresh();
+            }
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    if (holdStatus === "other") {
+        return (
+            <Button size="sm" variant="outline" disabled className="gap-2">
+                <Hand className="h-4 w-4" />
+                On Hold by {holdUserName}
+            </Button>
+        );
+    }
+
+    if (holdStatus === "own") {
+        return (
+            <Button
+                size="sm"
+                variant="outline"
+                onClick={handleRemoveHold}
+                disabled={loading}
+                className="gap-2"
+            >
+                <Hand className="h-4 w-4" />
+                {loading ? "Removing..." : "Remove Hold"}
+            </Button>
+        );
+    }
+
+    return (
+        <Button
+            size="sm"
+            onClick={handleRequestHold}
+            disabled={loading}
+            className="gap-2"
+        >
+            <Hand className="h-4 w-4" />
+            {loading ? "Requesting..." : "Request Hold"}
+        </Button>
+    );
+}

--- a/src/app/works/[id]/page.tsx
+++ b/src/app/works/[id]/page.tsx
@@ -8,6 +8,7 @@ import { getAllUsers } from "@/lib/data/users";
 import { isWorkCheckedOut, getActiveCheckoutForWork, getCheckoutById, hasReturnedCheckout } from "@/lib/data/checkouts";
 import { getTagsForWork, getAllTags } from "@/lib/data/tags";
 import { getWorkRatingSummary, getUserRatingForWork } from "@/lib/data/ratings";
+import { getHoldForWork } from "@/lib/data/holds";
 import { getCurrentUser } from "@/lib/auth";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -16,6 +17,7 @@ import { CheckoutWorkButton } from "./checkout-work-button";
 import { ReturnWorkButton } from "./return-work-button";
 import { WorkTagsEditor } from "@/app/staff/work-tags-editor";
 import { StarRating } from "@/components/star-rating";
+import { HoldWorkButton } from "./hold-work-button";
 
 export const revalidate = 0; // Dynamic page
 
@@ -39,6 +41,12 @@ export default async function WorkPage({ params }: PageProps) {
 
     const workTags = await getTagsForWork(work.id);
     const ratingSummary = await getWorkRatingSummary(work.id);
+    const hold = await getHoldForWork(work.id);
+
+    let holdStatus: "none" | "own" | "other" = "none";
+    if (hold) {
+        holdStatus = user && hold.user_id === user.id ? "own" : "other";
+    }
 
     let userRating = null;
     let canRate = false;
@@ -85,15 +93,24 @@ export default async function WorkPage({ params }: PageProps) {
                     </Link>
                 </Button>
 
-                {isStaffOrAdmin && (
-                    <div className="mr-4 flex gap-2">
-                        {isCheckedOut && activeCheckout && (
-                            <ReturnWorkButton checkout={activeCheckout} />
-                        )}
-                        <CheckoutWorkButton work={work} users={allUsers} disabled={isCheckedOut} />
-                        <EditWorkButton work={work} />
-                    </div>
-                )}
+                <div className="mr-4 flex gap-2">
+                    {user && (
+                        <HoldWorkButton
+                            workId={work.id}
+                            holdStatus={holdStatus}
+                            holdUserName={hold?.user_name}
+                        />
+                    )}
+                    {isStaffOrAdmin && (
+                        <>
+                            {isCheckedOut && activeCheckout && (
+                                <ReturnWorkButton checkout={activeCheckout} />
+                            )}
+                            <CheckoutWorkButton work={work} users={allUsers} disabled={isCheckedOut} />
+                            <EditWorkButton work={work} />
+                        </>
+                    )}
+                </div>
             </div>
 
             <div className="flex flex-col md:flex-row gap-8 lg:gap-12">

--- a/src/lib/data/checkouts.ts
+++ b/src/lib/data/checkouts.ts
@@ -201,6 +201,9 @@ export async function createCheckout(input: {
         [input.work_id, input.user_id, input.due_date]
     );
 
+    // Remove any hold on this work since it's now checked out
+    await query("DELETE FROM holds WHERE work_id = $1", [input.work_id]);
+
     return result.rows[0] as CheckoutBaseDTO;
 }
 

--- a/src/lib/data/holds.ts
+++ b/src/lib/data/holds.ts
@@ -1,0 +1,124 @@
+import "server-only";
+
+import { query } from "@/lib/db";
+import { getCurrentUser } from "@/lib/auth";
+
+// ---------------------------------------------------------------------------
+// Types / DTOs
+// ---------------------------------------------------------------------------
+
+export interface HoldDTO {
+    id: string;
+    work_id: string;
+    user_id: string;
+    user_name: string;
+    created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function requireAuthenticatedUser() {
+    const user = await getCurrentUser();
+    if (!user) {
+        throw new Error("Unauthorized");
+    }
+    return user;
+}
+
+// ---------------------------------------------------------------------------
+// Read operations
+// ---------------------------------------------------------------------------
+
+/** Get the current hold for a work, or null (public). */
+export async function getHoldForWork(
+    workId: string
+): Promise<HoldDTO | null> {
+    const result = await query(
+        `SELECT h.id, h.work_id, h.user_id, u.name AS user_name, h.created_at
+         FROM holds h
+         JOIN users u ON u.id = h.user_id
+         WHERE h.work_id = $1`,
+        [workId]
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0] as HoldDTO;
+}
+
+// ---------------------------------------------------------------------------
+// Write operations
+// ---------------------------------------------------------------------------
+
+/** Place a hold on a work (authenticated). */
+export async function createHold(workId: string): Promise<HoldDTO> {
+    const user = await requireAuthenticatedUser();
+
+    // Check that the work exists
+    const workResult = await query("SELECT id FROM works WHERE id = $1", [
+        workId,
+    ]);
+    if (workResult.rows.length === 0) {
+        throw new Error("Work not found");
+    }
+
+    // Check if work is already on hold
+    const existingHold = await query(
+        "SELECT id FROM holds WHERE work_id = $1",
+        [workId]
+    );
+    if (existingHold.rows.length > 0) {
+        throw new Error("This work is already on hold");
+    }
+
+    // Check if user already has a hold
+    const userHold = await query(
+        "SELECT id FROM holds WHERE user_id = $1",
+        [user.id]
+    );
+    if (userHold.rows.length > 0) {
+        throw new Error("You already have a work on hold");
+    }
+
+    const result = await query(
+        `INSERT INTO holds (work_id, user_id)
+         VALUES ($1, $2)
+         RETURNING id, work_id, user_id, created_at`,
+        [workId, user.id]
+    );
+
+    const hold = result.rows[0];
+
+    return {
+        id: hold.id,
+        work_id: hold.work_id,
+        user_id: hold.user_id,
+        user_name: user.name,
+        created_at: hold.created_at,
+    } as HoldDTO;
+}
+
+/** Remove a hold on a work (owner or staff/admin). */
+export async function deleteHold(workId: string): Promise<void> {
+    const user = await requireAuthenticatedUser();
+
+    const holdResult = await query(
+        "SELECT id, user_id FROM holds WHERE work_id = $1",
+        [workId]
+    );
+
+    if (holdResult.rows.length === 0) {
+        throw new Error("Hold not found");
+    }
+
+    const hold = holdResult.rows[0];
+    const isOwner = hold.user_id === user.id;
+    const isStaffOrAdmin = user.role === "staff" || user.role === "admin";
+
+    if (!isOwner && !isStaffOrAdmin) {
+        throw new Error("Forbidden");
+    }
+
+    await query("DELETE FROM holds WHERE id = $1", [hold.id]);
+}

--- a/src/lib/migrations/007_create_holds_table.sql
+++ b/src/lib/migrations/007_create_holds_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS holds (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  work_id BIGINT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (work_id),
+  UNIQUE (user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_holds_work_id ON holds(work_id);
+CREATE INDEX IF NOT EXISTS idx_holds_user_id ON holds(user_id);


### PR DESCRIPTION
## Summary
- Allow authenticated users to place a hold on a work (one per user, one per work)
- Holds are informational — staff can still check out held works
- Holds are auto-removed when a work is checked out
- Hold button appears for all logged-in users on the work detail page

## Changes
- **Migration:** `007_create_holds_table.sql` with UNIQUE constraints on `work_id` and `user_id`
- **Data layer:** `holds.ts` with `getHoldForWork`, `createHold`, `deleteHold`
- **API route:** GET/POST/DELETE at `/api/works/[id]/hold`
- **UI:** `HoldWorkButton` component with three states (Request Hold / Remove Hold / On Hold by {name})
- **Checkout cleanup:** auto-delete hold when staff checks out a held work
- **Tests:** full coverage for data layer and API routes

## Test plan
- [x] All 429 tests pass
- [x] Log in as user, place hold on a work, verify button changes to "Remove Hold"
- [x] Log in as different user, verify "On Hold by {name}" shown (disabled)
- [x] Log in as staff, verify checkout still works on held work and hold is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)