### PR TITLE
feat: add book checkout history view for staff

### DIFF
--- a/src/__tests__/lib/data/checkouts.test.ts
+++ b/src/__tests__/lib/data/checkouts.test.ts
@@ -29,6 +29,7 @@ import {
     rejectCheckoutExtension,
     getActiveCheckoutForWork,
     getPopularWorks,
+    getCheckoutHistoryForWork,
 } from "@/lib/data/checkouts";
 
 const staffUser = {
@@ -506,5 +507,73 @@ describe("getPopularWorks", () => {
 
         // Should NOT throw even though there's no authenticated user
         await expect(getPopularWorks()).resolves.toEqual([]);
+    });
+});
+
+// ─── getCheckoutHistoryForWork ───────────────────────────────────────
+
+describe("getCheckoutHistoryForWork", () => {
+    it("throws Unauthorized when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        await expect(getCheckoutHistoryForWork("w1")).rejects.toThrow("Unauthorized");
+    });
+
+    it("throws Forbidden when role is user", async () => {
+        mockGetCurrentUser.mockResolvedValue(regularUser);
+        await expect(getCheckoutHistoryForWork("w1")).rejects.toThrow("Forbidden");
+    });
+
+    it("allows admin users", async () => {
+        mockGetCurrentUser.mockResolvedValue(adminUser);
+        mockQuery.mockResolvedValue({ rows: [] });
+        await expect(getCheckoutHistoryForWork("w1")).resolves.toEqual([]);
+    });
+
+    it("returns empty array when work has no checkouts", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+        const result = await getCheckoutHistoryForWork("w1");
+        expect(result).toEqual([]);
+    });
+
+    it("returns checkouts with joined work and user data", async () => {
+        const checkouts = [
+            {
+                id: "c1",
+                work_id: "w1",
+                user_id: "u1",
+                work_title: "Book A",
+                user_name: "Alice",
+                user_email: "alice@example.com",
+            },
+            {
+                id: "c2",
+                work_id: "w1",
+                user_id: "u2",
+                work_title: "Book A",
+                user_name: "Bob",
+                user_email: "bob@example.com",
+            },
+        ];
+        mockQuery.mockResolvedValue({ rows: checkouts });
+
+        const result = await getCheckoutHistoryForWork("w1");
+
+        expect(result).toEqual(checkouts);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("JOIN works"),
+            ["w1"]
+        );
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("JOIN users"),
+            ["w1"]
+        );
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("WHERE c.work_id = $1"),
+            ["w1"]
+        );
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("ORDER BY c.checked_out_at DESC"),
+            ["w1"]
+        );
     });
 });

--- a/src/app/works/[id]/page.tsx
+++ b/src/app/works/[id]/page.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, BookOpen, Clock, Globe, Hash, Library, MapPin, Building, Use
 
 import { getPublicWorkById } from "@/lib/data/works";
 import { getAllUsers } from "@/lib/data/users";
-import { isWorkCheckedOut, getActiveCheckoutForWork, getCheckoutById, hasReturnedCheckout } from "@/lib/data/checkouts";
+import { isWorkCheckedOut, getActiveCheckoutForWork, getCheckoutById, hasReturnedCheckout, getCheckoutHistoryForWork } from "@/lib/data/checkouts";
 import { getTagsForWork, getAllTags } from "@/lib/data/tags";
 import { getWorkRatingSummary, getUserRatingForWork } from "@/lib/data/ratings";
 import { getHoldForWork } from "@/lib/data/holds";
@@ -18,6 +18,7 @@ import { ReturnWorkButton } from "./return-work-button";
 import { WorkTagsEditor } from "@/app/staff/work-tags-editor";
 import { StarRating } from "@/components/star-rating";
 import { HoldWorkButton } from "./hold-work-button";
+import { WorkCheckoutHistory } from "../work-checkout-history";
 
 export const revalidate = 0; // Dynamic page
 
@@ -63,6 +64,7 @@ export default async function WorkPage({ params }: PageProps) {
     let allTags: any[] = [];
     let isCheckedOut = false;
     let activeCheckout = null;
+    let checkoutHistory: any[] = [];
 
     if (isStaffOrAdmin) {
         allUsers = await getAllUsers();
@@ -74,6 +76,7 @@ export default async function WorkPage({ params }: PageProps) {
                 activeCheckout = await getCheckoutById(activeCheckoutId);
             }
         }
+        checkoutHistory = await getCheckoutHistoryForWork(work.id);
     }
 
     const yearPublished = work.date_published
@@ -273,6 +276,9 @@ export default async function WorkPage({ params }: PageProps) {
 
                 </div>
             </div>
+            {isStaffOrAdmin && (
+                <WorkCheckoutHistory checkouts={checkoutHistory} />
+            )}
         </div>
     );
 }

--- a/src/app/works/work-checkout-history.tsx
+++ b/src/app/works/work-checkout-history.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import type { CheckoutDTO } from "@/lib/data/checkouts";
+
+interface WorkCheckoutHistoryProps {
+    checkouts: CheckoutDTO[];
+}
+
+function getStatus(checkout: CheckoutDTO): {
+    label: string;
+    variant: "default" | "secondary" | "destructive" | "outline";
+} {
+    if (checkout.returned_at) {
+        return { label: "Returned", variant: "secondary" };
+    }
+    if (new Date(checkout.due_date) < new Date()) {
+        return { label: "Overdue", variant: "destructive" };
+    }
+    return { label: "Active", variant: "default" };
+}
+
+function formatDate(dateStr: string | null): string {
+    if (!dateStr) return "—";
+    return new Date(dateStr).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+    });
+}
+
+export function WorkCheckoutHistory({ checkouts }: WorkCheckoutHistoryProps) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <div className="mt-10 border rounded-lg overflow-hidden">
+            <button
+                onClick={() => setOpen((v) => !v)}
+                className="w-full flex items-center justify-between px-4 py-3 bg-muted/50 hover:bg-muted transition-colors text-sm font-medium"
+            >
+                <span>Checkout History ({checkouts.length})</span>
+                {open ? (
+                    <ChevronUp className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                )}
+            </button>
+
+            {open && (
+                <div className="p-4">
+                    {checkouts.length === 0 ? (
+                        <p className="text-sm text-muted-foreground text-center py-4">
+                            No checkout history yet.
+                        </p>
+                    ) : (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Borrower</TableHead>
+                                    <TableHead>Checked Out</TableHead>
+                                    <TableHead>Due Date</TableHead>
+                                    <TableHead>Returned</TableHead>
+                                    <TableHead>Status</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {checkouts.map((checkout) => {
+                                    const status = getStatus(checkout);
+                                    return (
+                                        <TableRow key={checkout.id}>
+                                            <TableCell>
+                                                <div className="font-medium">{checkout.user_name}</div>
+                                                <div className="text-xs text-muted-foreground">
+                                                    {checkout.user_email}
+                                                </div>
+                                            </TableCell>
+                                            <TableCell>{formatDate(checkout.checked_out_at)}</TableCell>
+                                            <TableCell>{formatDate(checkout.due_date)}</TableCell>
+                                            <TableCell>{formatDate(checkout.returned_at)}</TableCell>
+                                            <TableCell>
+                                                <Badge variant={status.variant}>{status.label}</Badge>
+                                            </TableCell>
+                                        </TableRow>
+                                    );
+                                })}
+                            </TableBody>
+                        </Table>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/lib/data/checkouts.ts
+++ b/src/lib/data/checkouts.ts
@@ -95,6 +95,28 @@ export async function getCheckoutById(
     return result.rows[0] as CheckoutDTO;
 }
 
+/** Get all checkouts for a given work ID, sorted newest first (staff only). */
+export async function getCheckoutHistoryForWork(
+    workId: string
+): Promise<CheckoutDTO[]> {
+    await requireStaffUser();
+
+    const result = await query(
+        `SELECT c.id, c.work_id, c.user_id, c.checked_out_at, c.due_date,
+                c.returned_at, c.reminder_sent_at, c.extension_status, c.created_at, c.updated_at,
+                w.title AS work_title,
+                u.name AS user_name, u.email AS user_email
+         FROM checkouts c
+         JOIN works w ON w.id = c.work_id
+         JOIN users u ON u.id = c.user_id
+         WHERE c.work_id = $1
+         ORDER BY c.checked_out_at DESC`,
+        [workId]
+    );
+
+    return result.rows as CheckoutDTO[];
+}
+
 /** Get all checkouts for a given user ID.  */
 export async function getUserCheckouts(userId: string): Promise<CheckoutDTO[]> {
     const result = await query(


### PR DESCRIPTION
## Summary
- Staff can now see a collapsible **Checkout History** section at the bottom of each work's detail page (`/works/[id]`)
- Shows every borrower (name + email), checked-out date, due date, returned date, and status badge (Active / Overdue / Returned)
- Sorted newest first; includes both active and returned checkouts
- Section is staff/admin-only and hidden from regular users

## Changes
- `src/lib/data/checkouts.ts` — added `getCheckoutHistoryForWork(workId)` (staff-only, queries all checkouts for a work ordered by `checked_out_at DESC`)
- `src/app/works/work-checkout-history.tsx` — new client component with collapsible toggle and table layout
- `src/app/works/[id]/page.tsx` — fetches history inside the `isStaffOrAdmin` block and renders the component

## Tests
- 5 new tests for `getCheckoutHistoryForWork`: auth guards (Unauthorized, Forbidden), admin access, empty state, joined data + ordering
- All 43 checkout data layer tests pass

## Test plan
- [ ] As staff/admin: navigate to any `/works/[id]` — "Checkout History (N)" section appears at bottom, toggles open/closed
- [ ] With no checkouts: empty state message shown
- [ ] With active + returned checkouts: correct status badges, rows sorted newest first
- [ ] As a regular user: history section is not rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)