### PR TITLE
feat(notifications): add in-app overdue book notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Database
 DATABASE_URL=postgresql://username:password@localhost:5432/database_name
 
+# Cron job authentication (any random string — must match Authorization: Bearer header)
+CRON_SECRET=your-random-secret-here
+
+# Email (Resend) — optional, falls back to console logging if not set
+RESEND_API_KEY=your-resend-api-key-here
+
 # Next.js
 # NEXT_PUBLIC_ prefix makes variables available in the browser
 # NEXT_PUBLIC_API_URL=http://localhost:3000/api

--- a/src/__tests__/api/cron/overdue/route.test.ts
+++ b/src/__tests__/api/cron/overdue/route.test.ts
@@ -1,0 +1,184 @@
+/**
+ * @jest-environment node
+ */
+
+const mockGetOverdueCheckouts = jest.fn();
+const mockMarkOverdueNotified = jest.fn();
+const mockGetStaffAndAdminUsers = jest.fn();
+const mockCreateNotification = jest.fn();
+
+jest.mock("@/lib/data/checkouts", () => ({
+    getOverdueCheckouts: () => mockGetOverdueCheckouts(),
+    markOverdueNotified: (id: string) => mockMarkOverdueNotified(id),
+}));
+
+jest.mock("@/lib/data/users", () => ({
+    getStaffAndAdminUsers: () => mockGetStaffAndAdminUsers(),
+}));
+
+jest.mock("@/lib/data/notifications", () => ({
+    createNotification: (userId: string, message: string, checkoutId?: string) =>
+        mockCreateNotification(userId, message, checkoutId),
+}));
+
+import { GET } from "@/app/api/cron/overdue/route";
+import { NextRequest } from "next/server";
+
+const CRON_SECRET = "test-secret";
+
+function makeRequest(token?: string): NextRequest {
+    const headers: Record<string, string> = {};
+    if (token !== undefined) {
+        headers["Authorization"] = `Bearer ${token}`;
+    }
+    return new NextRequest("http://localhost:3000/api/cron/overdue", {
+        method: "GET",
+        headers,
+    });
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CRON_SECRET = CRON_SECRET;
+});
+
+// ─── Auth ───────────────────────────────────────────────────────────
+
+describe("GET /api/cron/overdue — auth", () => {
+    it("returns 401 when Authorization header is missing", async () => {
+        const req = new NextRequest("http://localhost:3000/api/cron/overdue", {
+            method: "GET",
+        });
+        const res = await GET(req);
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 401 when token is wrong", async () => {
+        const res = await GET(makeRequest("wrong-token"));
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 401 when Authorization header does not start with Bearer", async () => {
+        const req = new NextRequest("http://localhost:3000/api/cron/overdue", {
+            method: "GET",
+            headers: { Authorization: `Token ${CRON_SECRET}` },
+        });
+        const res = await GET(req);
+        expect(res.status).toBe(401);
+    });
+});
+
+// ─── No overdue checkouts ────────────────────────────────────────────
+
+describe("GET /api/cron/overdue — no overdue", () => {
+    it("returns 200 with processed 0 when no overdue checkouts", async () => {
+        mockGetOverdueCheckouts.mockResolvedValue([]);
+
+        const res = await GET(makeRequest(CRON_SECRET));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.processed).toBe(0);
+        expect(mockCreateNotification).not.toHaveBeenCalled();
+        expect(mockMarkOverdueNotified).not.toHaveBeenCalled();
+    });
+});
+
+// ─── Happy path ──────────────────────────────────────────────────────
+
+describe("GET /api/cron/overdue — happy path", () => {
+    const overdueCheckouts = [
+        {
+            id: "c1",
+            user_id: "user-1",
+            due_date: "2026-01-01T00:00:00Z",
+            user_email: "alice@example.com",
+            user_name: "Alice",
+            work_title: "Book A",
+        },
+        {
+            id: "c2",
+            user_id: "user-2",
+            due_date: "2026-01-05T00:00:00Z",
+            user_email: "bob@example.com",
+            user_name: "Bob",
+            work_title: "Book B",
+        },
+    ];
+
+    const staffUsers = [
+        { id: "staff-1", name: "Staff Member" },
+    ];
+
+    beforeEach(() => {
+        mockGetOverdueCheckouts.mockResolvedValue(overdueCheckouts);
+        mockGetStaffAndAdminUsers.mockResolvedValue(staffUsers);
+        mockCreateNotification.mockResolvedValue(undefined);
+        mockMarkOverdueNotified.mockResolvedValue(undefined);
+    });
+
+    it("returns 200 with processed count", async () => {
+        const res = await GET(makeRequest(CRON_SECRET));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.processed).toBe(2);
+    });
+
+    it("creates a notification for each borrower", async () => {
+        await GET(makeRequest(CRON_SECRET));
+
+        expect(mockCreateNotification).toHaveBeenCalledWith(
+            "user-1",
+            expect.stringContaining("Book A"),
+            "c1"
+        );
+        expect(mockCreateNotification).toHaveBeenCalledWith(
+            "user-2",
+            expect.stringContaining("Book B"),
+            "c2"
+        );
+    });
+
+    it("creates a notification for each staff user per overdue checkout", async () => {
+        await GET(makeRequest(CRON_SECRET));
+
+        expect(mockCreateNotification).toHaveBeenCalledWith(
+            "staff-1",
+            expect.stringContaining("Book A"),
+            "c1"
+        );
+        expect(mockCreateNotification).toHaveBeenCalledWith(
+            "staff-1",
+            expect.stringContaining("Book B"),
+            "c2"
+        );
+    });
+
+    it("marks each checkout as overdue-notified", async () => {
+        await GET(makeRequest(CRON_SECRET));
+
+        expect(mockMarkOverdueNotified).toHaveBeenCalledTimes(2);
+        expect(mockMarkOverdueNotified).toHaveBeenCalledWith("c1");
+        expect(mockMarkOverdueNotified).toHaveBeenCalledWith("c2");
+    });
+
+    it("total notifications = (checkouts × (1 borrower + N staff))", async () => {
+        await GET(makeRequest(CRON_SECRET));
+
+        // 2 checkouts × (1 user + 1 staff) = 4 notifications
+        expect(mockCreateNotification).toHaveBeenCalledTimes(4);
+    });
+});
+
+// ─── Error handling ──────────────────────────────────────────────────
+
+describe("GET /api/cron/overdue — error handling", () => {
+    it("returns 500 when getOverdueCheckouts throws", async () => {
+        mockGetOverdueCheckouts.mockRejectedValue(new Error("DB error"));
+
+        const res = await GET(makeRequest(CRON_SECRET));
+
+        expect(res.status).toBe(500);
+    });
+});

--- a/src/__tests__/api/notifications/route.test.ts
+++ b/src/__tests__/api/notifications/route.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment node
+ */
+
+const mockGetCurrentUser = jest.fn();
+jest.mock("@/lib/auth", () => ({
+    getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+jest.mock("next/headers", () => ({
+    cookies: jest.fn(),
+}));
+
+const mockGetUnreadNotifications = jest.fn();
+const mockMarkNotificationRead = jest.fn();
+const mockMarkAllNotificationsRead = jest.fn();
+
+jest.mock("@/lib/data/notifications", () => ({
+    getUnreadNotifications: (userId: string) => mockGetUnreadNotifications(userId),
+    markNotificationRead: (id: string, userId: string) =>
+        mockMarkNotificationRead(id, userId),
+    markAllNotificationsRead: (userId: string) =>
+        mockMarkAllNotificationsRead(userId),
+}));
+
+import { GET } from "@/app/api/notifications/route";
+import { PUT as PUT_READ } from "@/app/api/notifications/[id]/read/route";
+import { PUT as PUT_READ_ALL } from "@/app/api/notifications/read-all/route";
+import { NextRequest } from "next/server";
+
+const user = { id: "user-1", email: "user@example.com", name: "User", role: "user" };
+
+function makeParams(id: string) {
+    return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue(user);
+});
+
+// ─── GET /api/notifications ──────────────────────────────────────────
+
+describe("GET /api/notifications", () => {
+    it("returns 401 when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        const res = await GET();
+        expect(res.status).toBe(401);
+    });
+
+    it("returns unread notifications for the current user", async () => {
+        const notifications = [
+            { id: "n1", message: "Book overdue", checkout_id: "c1", created_at: "2026-01-01T00:00:00Z" },
+        ];
+        mockGetUnreadNotifications.mockResolvedValue(notifications);
+
+        const res = await GET();
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual(notifications);
+        expect(mockGetUnreadNotifications).toHaveBeenCalledWith("user-1");
+    });
+
+    it("returns empty array when no notifications", async () => {
+        mockGetUnreadNotifications.mockResolvedValue([]);
+
+        const res = await GET();
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual([]);
+    });
+
+    it("returns 500 on unexpected error", async () => {
+        mockGetCurrentUser.mockRejectedValue(new Error("DB error"));
+        const res = await GET();
+        expect(res.status).toBe(500);
+    });
+});
+
+// ─── PUT /api/notifications/[id]/read ───────────────────────────────
+
+describe("PUT /api/notifications/[id]/read", () => {
+    it("returns 401 when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        const req = new NextRequest("http://localhost:3000/api/notifications/n1/read", {
+            method: "PUT",
+        });
+        const res = await PUT_READ(req, makeParams("n1"));
+        expect(res.status).toBe(401);
+    });
+
+    it("marks the notification as read", async () => {
+        mockMarkNotificationRead.mockResolvedValue(undefined);
+        const req = new NextRequest("http://localhost:3000/api/notifications/n1/read", {
+            method: "PUT",
+        });
+        const res = await PUT_READ(req, makeParams("n1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(mockMarkNotificationRead).toHaveBeenCalledWith("n1", "user-1");
+    });
+
+    it("returns 500 on unexpected error", async () => {
+        mockGetCurrentUser.mockRejectedValue(new Error("DB error"));
+        const req = new NextRequest("http://localhost:3000/api/notifications/n1/read", {
+            method: "PUT",
+        });
+        const res = await PUT_READ(req, makeParams("n1"));
+        expect(res.status).toBe(500);
+    });
+});
+
+// ─── PUT /api/notifications/read-all ────────────────────────────────
+
+describe("PUT /api/notifications/read-all", () => {
+    it("returns 401 when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        const res = await PUT_READ_ALL();
+        expect(res.status).toBe(401);
+    });
+
+    it("marks all notifications as read", async () => {
+        mockMarkAllNotificationsRead.mockResolvedValue(undefined);
+        const res = await PUT_READ_ALL();
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(mockMarkAllNotificationsRead).toHaveBeenCalledWith("user-1");
+    });
+
+    it("returns 500 on unexpected error", async () => {
+        mockGetCurrentUser.mockRejectedValue(new Error("DB error"));
+        const res = await PUT_READ_ALL();
+        expect(res.status).toBe(500);
+    });
+});

--- a/src/__tests__/lib/data/checkouts.test.ts
+++ b/src/__tests__/lib/data/checkouts.test.ts
@@ -29,6 +29,8 @@ import {
     rejectCheckoutExtension,
     getActiveCheckoutForWork,
     getPopularWorks,
+    getOverdueCheckouts,
+    markOverdueNotified,
 } from "@/lib/data/checkouts";
 
 const staffUser = {
@@ -445,6 +447,63 @@ describe("rejectCheckoutExtension", () => {
         expect(result).toEqual(updatedCheckout);
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("extension_status = 'rejected'"),
+            ["c1"]
+        );
+    });
+});
+
+// ─── getOverdueCheckouts ────────────────────────────────────────────
+
+describe("getOverdueCheckouts", () => {
+    it("returns overdue checkouts with joined data", async () => {
+        const checkouts = [
+            {
+                id: "c1",
+                user_id: "u1",
+                due_date: "2026-01-01T00:00:00Z",
+                user_email: "alice@example.com",
+                user_name: "Alice",
+                work_title: "Book A",
+            },
+        ];
+        mockQuery.mockResolvedValue({ rows: checkouts });
+
+        const result = await getOverdueCheckouts();
+
+        expect(result).toEqual(checkouts);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("c.returned_at IS NULL"),
+            undefined
+        );
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("c.due_date < NOW()"),
+            undefined
+        );
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("c.overdue_notified_at IS NULL"),
+            undefined
+        );
+    });
+
+    it("returns empty array when no overdue checkouts", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        const result = await getOverdueCheckouts();
+
+        expect(result).toEqual([]);
+    });
+});
+
+// ─── markOverdueNotified ────────────────────────────────────────────
+
+describe("markOverdueNotified", () => {
+    it("updates overdue_notified_at", async () => {
+        mockQuery.mockResolvedValue({ rowCount: 1, rows: [] });
+
+        await markOverdueNotified("c1");
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("UPDATE checkouts SET overdue_notified_at"),
             ["c1"]
         );
     });

--- a/src/__tests__/lib/data/notifications.test.ts
+++ b/src/__tests__/lib/data/notifications.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment node
+ */
+
+const mockGetCurrentUser = jest.fn();
+jest.mock("@/lib/auth", () => ({
+    getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+jest.mock("next/headers", () => ({
+    cookies: jest.fn(),
+}));
+
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({
+    query: (text: string, params?: unknown[]) => mockQuery(text, params),
+}));
+
+import {
+    createNotification,
+    getUnreadNotifications,
+    markNotificationRead,
+    markAllNotificationsRead,
+} from "@/lib/data/notifications";
+
+const regularUser = { id: "user-1", email: "user@example.com", name: "User", role: "user" };
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue(regularUser);
+});
+
+// ─── createNotification ─────────────────────────────────────────────
+
+describe("createNotification", () => {
+    it("inserts a notification with checkoutId", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        await createNotification("user-1", "Your book is overdue.", "checkout-1");
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("INSERT INTO notifications"),
+            ["user-1", "Your book is overdue.", "checkout-1"]
+        );
+    });
+
+    it("inserts a notification without checkoutId (null)", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        await createNotification("user-1", "A message.");
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("INSERT INTO notifications"),
+            ["user-1", "A message.", null]
+        );
+    });
+});
+
+// ─── getUnreadNotifications ─────────────────────────────────────────
+
+describe("getUnreadNotifications", () => {
+    it("throws Unauthorized when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        await expect(getUnreadNotifications("user-1")).rejects.toThrow("Unauthorized");
+    });
+
+    it("returns unread notifications for the user", async () => {
+        const rows = [
+            { id: "n1", message: "Book overdue", checkout_id: "c1", created_at: "2026-01-01T00:00:00Z" },
+        ];
+        mockQuery.mockResolvedValue({ rows });
+
+        const result = await getUnreadNotifications("user-1");
+
+        expect(result).toEqual(rows);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("read_at IS NULL"),
+            ["user-1"]
+        );
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("ORDER BY created_at DESC"),
+            ["user-1"]
+        );
+    });
+
+    it("returns empty array when no unread notifications", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        const result = await getUnreadNotifications("user-1");
+
+        expect(result).toEqual([]);
+    });
+});
+
+// ─── markNotificationRead ───────────────────────────────────────────
+
+describe("markNotificationRead", () => {
+    it("throws Unauthorized when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        await expect(markNotificationRead("n1", "user-1")).rejects.toThrow("Unauthorized");
+    });
+
+    it("updates read_at scoped to user_id", async () => {
+        mockQuery.mockResolvedValue({ rowCount: 1 });
+
+        await markNotificationRead("n1", "user-1");
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("UPDATE notifications SET read_at"),
+            ["n1", "user-1"]
+        );
+    });
+});
+
+// ─── markAllNotificationsRead ───────────────────────────────────────
+
+describe("markAllNotificationsRead", () => {
+    it("throws Unauthorized when not authenticated", async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        await expect(markAllNotificationsRead("user-1")).rejects.toThrow("Unauthorized");
+    });
+
+    it("marks all unread notifications for the user", async () => {
+        mockQuery.mockResolvedValue({ rowCount: 3 });
+
+        await markAllNotificationsRead("user-1");
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("UPDATE notifications SET read_at"),
+            ["user-1"]
+        );
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("WHERE user_id = $1"),
+            ["user-1"]
+        );
+    });
+});

--- a/src/app/api/cron/overdue/route.ts
+++ b/src/app/api/cron/overdue/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+    getOverdueCheckouts,
+    markOverdueNotified,
+} from "@/lib/data/checkouts";
+import { getStaffAndAdminUsers } from "@/lib/data/users";
+import { createNotification } from "@/lib/data/notifications";
+
+export async function GET(req: NextRequest) {
+    // 1. Authorization check based on CRON_SECRET
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const token = authHeader.split(" ")[1];
+    if (token !== process.env.CRON_SECRET) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    try {
+        // 2. Fetch all newly overdue checkouts
+        const overdueCheckouts = await getOverdueCheckouts();
+
+        if (overdueCheckouts.length === 0) {
+            return NextResponse.json({ message: "No overdue checkouts", processed: 0 });
+        }
+
+        // 3. Fetch staff/admin users once
+        const staffUsers = await getStaffAndAdminUsers();
+
+        // 4. For each overdue checkout, notify the borrower and all staff
+        for (const checkout of overdueCheckouts) {
+            const dueDate = new Date(checkout.due_date).toLocaleDateString();
+
+            // Notify the borrower
+            await createNotification(
+                checkout.user_id,
+                `Your copy of "${checkout.work_title}" was due on ${dueDate} and is now overdue. Please return it as soon as possible.`,
+                checkout.id
+            );
+
+            // Notify each staff/admin user
+            for (const staff of staffUsers) {
+                await createNotification(
+                    staff.id,
+                    `"${checkout.work_title}" checked out by ${checkout.user_name} was due on ${dueDate} and is now overdue.`,
+                    checkout.id
+                );
+            }
+
+            // Mark to prevent re-triggering
+            await markOverdueNotified(checkout.id);
+        }
+
+        return NextResponse.json({
+            message: "Overdue notifications created",
+            processed: overdueCheckouts.length,
+        });
+    } catch (error) {
+        console.error("Failed to process overdue notifications:", error);
+        return NextResponse.json(
+            { error: "Internal Server Error" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/notifications/[id]/read/route.ts
+++ b/src/app/api/notifications/[id]/read/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { markNotificationRead } from "@/lib/data/notifications";
+
+export async function PUT(
+    _req: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    try {
+        const user = await getCurrentUser();
+        if (!user) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const { id } = await params;
+        await markNotificationRead(id, user.id);
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("Failed to mark notification as read:", error);
+        return NextResponse.json(
+            { error: "Internal Server Error" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/notifications/read-all/route.ts
+++ b/src/app/api/notifications/read-all/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { markAllNotificationsRead } from "@/lib/data/notifications";
+
+export async function PUT() {
+    try {
+        const user = await getCurrentUser();
+        if (!user) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        await markAllNotificationsRead(user.id);
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("Failed to mark all notifications as read:", error);
+        return NextResponse.json(
+            { error: "Internal Server Error" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { getUnreadNotifications } from "@/lib/data/notifications";
+
+export async function GET() {
+    try {
+        const user = await getCurrentUser();
+        if (!user) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const notifications = await getUnreadNotifications(user.id);
+        return NextResponse.json(notifications);
+    } catch (error) {
+        console.error("Failed to fetch notifications:", error);
+        return NextResponse.json(
+            { error: "Internal Server Error" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getCurrentUser } from "@/lib/auth";
 import { LogoutButton } from "@/components/logout-button";
+import { NotificationBell } from "@/components/notification-bell";
 import { Button } from "@/components/ui/button";
 
 export async function Header() {
@@ -31,6 +32,7 @@ export async function Header() {
               <Button variant="ghost" size="sm" className="text-primary-foreground hover:bg-white/15 hover:text-primary-foreground" asChild>
                 <Link href="/profile">My Profile</Link>
               </Button>
+              <NotificationBell />
               <span className="text-sm text-primary-foreground/70 ml-2">
                 {user.name}
               </span>

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Bell } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface Notification {
+    id: string;
+    message: string;
+    checkout_id: string | null;
+    created_at: string;
+}
+
+export function NotificationBell() {
+    const [notifications, setNotifications] = useState<Notification[]>([]);
+
+    useEffect(() => {
+        fetch("/api/notifications")
+            .then((res) => res.json())
+            .then((data) => {
+                if (Array.isArray(data)) setNotifications(data);
+            })
+            .catch(() => {});
+    }, []);
+
+    async function markRead(id: string) {
+        await fetch(`/api/notifications/${id}/read`, { method: "PUT" });
+        setNotifications((prev) => prev.filter((n) => n.id !== id));
+    }
+
+    async function markAllRead() {
+        await fetch("/api/notifications/read-all", { method: "PUT" });
+        setNotifications([]);
+    }
+
+    const count = notifications.length;
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="relative text-primary-foreground hover:bg-white/15 hover:text-primary-foreground"
+                    aria-label="Notifications"
+                >
+                    <Bell className="h-4 w-4" />
+                    {count > 0 && (
+                        <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-[10px] font-bold text-destructive-foreground">
+                            {count > 9 ? "9+" : count}
+                        </span>
+                    )}
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-80">
+                {count === 0 ? (
+                    <div className="px-3 py-4 text-center text-sm text-muted-foreground">
+                        No new notifications
+                    </div>
+                ) : (
+                    <>
+                        {notifications.map((n) => (
+                            <DropdownMenuItem
+                                key={n.id}
+                                className="flex cursor-pointer flex-col items-start gap-1 px-3 py-2 whitespace-normal"
+                                onClick={() => markRead(n.id)}
+                            >
+                                <span className="text-sm">{n.message}</span>
+                                <span className="text-xs text-muted-foreground">
+                                    {new Date(n.created_at).toLocaleDateString()}
+                                </span>
+                            </DropdownMenuItem>
+                        ))}
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                            className="cursor-pointer justify-center text-sm text-muted-foreground"
+                            onClick={markAllRead}
+                        >
+                            Mark all as read
+                        </DropdownMenuItem>
+                    </>
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/src/lib/data/checkouts.ts
+++ b/src/lib/data/checkouts.ts
@@ -15,6 +15,7 @@ export interface CheckoutDTO {
     due_date: string;
     returned_at: string | null;
     reminder_sent_at: string | null;
+    overdue_notified_at: string | null;
     extension_status: "none" | "pending" | "approved" | "rejected";
     created_at: string;
     updated_at: string;
@@ -31,9 +32,19 @@ export interface CheckoutBaseDTO {
     due_date: string;
     returned_at: string | null;
     reminder_sent_at: string | null;
+    overdue_notified_at: string | null;
     extension_status: "none" | "pending" | "approved" | "rejected";
     created_at: string;
     updated_at: string;
+}
+
+export interface OverdueCheckoutDTO {
+    id: string;
+    user_id: string;
+    due_date: string;
+    user_email: string;
+    user_name: string;
+    work_title: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -390,4 +401,34 @@ export async function getPopularWorks(tagId?: string): Promise<PopularWorkDTO[]>
     );
 
     return result.rows as PopularWorkDTO[];
+}
+
+/**
+ * Get all active checkouts that are past their due date and haven't been notified yet.
+ */
+export async function getOverdueCheckouts(): Promise<OverdueCheckoutDTO[]> {
+    const result = await query(
+        `SELECT c.id, c.user_id, c.due_date,
+                u.email AS user_email, u.name AS user_name,
+                w.title AS work_title
+         FROM checkouts c
+         JOIN users u ON u.id = c.user_id
+         JOIN works w ON w.id = c.work_id
+         WHERE c.returned_at IS NULL
+           AND c.due_date < NOW()
+           AND c.overdue_notified_at IS NULL`
+    );
+
+    return result.rows as OverdueCheckoutDTO[];
+}
+
+/**
+ * Mark a checkout as having had an overdue notification sent.
+ */
+export async function markOverdueNotified(id: string): Promise<void> {
+    await query(
+        `UPDATE checkouts SET overdue_notified_at = NOW(), updated_at = NOW()
+         WHERE id = $1`,
+        [id]
+    );
 }

--- a/src/lib/data/notifications.ts
+++ b/src/lib/data/notifications.ts
@@ -1,0 +1,85 @@
+import "server-only";
+
+import { query } from "@/lib/db";
+import { getCurrentUser } from "@/lib/auth";
+
+// ---------------------------------------------------------------------------
+// Types / DTOs
+// ---------------------------------------------------------------------------
+
+export interface NotificationDTO {
+    id: string;
+    message: string;
+    checkout_id: string | null;
+    created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (no auth guard — called only from cron)
+// ---------------------------------------------------------------------------
+
+/** Create a notification for a user. */
+export async function createNotification(
+    userId: string,
+    message: string,
+    checkoutId?: string
+): Promise<void> {
+    await query(
+        `INSERT INTO notifications (user_id, message, checkout_id)
+         VALUES ($1, $2, $3)`,
+        [userId, message, checkoutId ?? null]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Read operations
+// ---------------------------------------------------------------------------
+
+/** Get all unread notifications for a user. */
+export async function getUnreadNotifications(
+    userId: string
+): Promise<NotificationDTO[]> {
+    const user = await getCurrentUser();
+    if (!user) throw new Error("Unauthorized");
+
+    const result = await query(
+        `SELECT id, message, checkout_id, created_at
+         FROM notifications
+         WHERE user_id = $1 AND read_at IS NULL
+         ORDER BY created_at DESC`,
+        [userId]
+    );
+
+    return result.rows as NotificationDTO[];
+}
+
+// ---------------------------------------------------------------------------
+// Write operations
+// ---------------------------------------------------------------------------
+
+/** Mark a single notification as read (scoped to the requesting user). */
+export async function markNotificationRead(
+    id: string,
+    userId: string
+): Promise<void> {
+    const user = await getCurrentUser();
+    if (!user) throw new Error("Unauthorized");
+
+    await query(
+        `UPDATE notifications SET read_at = NOW()
+         WHERE id = $1 AND user_id = $2 AND read_at IS NULL`,
+        [id, userId]
+    );
+}
+
+/** Mark all unread notifications as read for a user. */
+export async function markAllNotificationsRead(userId: string): Promise<void> {
+    const user = await getCurrentUser();
+    if (!user) throw new Error("Unauthorized");
+
+    await query(
+        `UPDATE notifications SET read_at = NOW()
+         WHERE user_id = $1 AND read_at IS NULL`,
+        [userId]
+    );
+}

--- a/src/lib/data/users.ts
+++ b/src/lib/data/users.ts
@@ -103,6 +103,15 @@ export async function registerUser(
 // Read operations (staff)
 // ---------------------------------------------------------------------------
 
+/** List all staff and admin users (id + name) for internal notification use. */
+export async function getStaffAndAdminUsers(): Promise<{ id: string; name: string }[]> {
+    const result = await query(
+        `SELECT id, name FROM users WHERE role IN ('staff', 'admin') ORDER BY name ASC`
+    );
+
+    return result.rows as { id: string; name: string }[];
+}
+
 /** List all users with minimal fields (staff only). */
 export async function getAllUsers(): Promise<UserListDTO[]> {
     await requireStaffUser();

--- a/src/lib/migrations/008_add_overdue_notified_to_checkouts.sql
+++ b/src/lib/migrations/008_add_overdue_notified_to_checkouts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE checkouts ADD COLUMN overdue_notified_at TIMESTAMPTZ;

--- a/src/lib/migrations/009_create_notifications_table.sql
+++ b/src/lib/migrations/009_create_notifications_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE notifications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    message TEXT NOT NULL,
+    checkout_id UUID REFERENCES checkouts(id) ON DELETE CASCADE,
+    read_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_notifications_user_id ON notifications(user_id);


### PR DESCRIPTION
## Summary
- Adds a `notifications` table to store in-app notifications per user
- Cron endpoint `/api/cron/overdue` creates notifications when books pass their due date — one for the borrower and one per staff/admin user
- Notification bell in the header shows unread count badge and a dropdown list; clicking a notification marks it read
- Adds `overdue_notified_at` to `checkouts` to prevent duplicate notifications across cron runs

## Test plan
- [x] Run `npm run migrate` to apply the two new migrations
- [x] Create a checkout with a past due date via the staff dashboard
- [x] Trigger the cron: `curl -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/api/cron/overdue`
- [x] Log in as the borrower — bell should show a badge with the overdue notice
- [x] Log in as staff/admin — bell should show a badge with the staff-facing notice
- [x] Click a notification to dismiss it; verify badge decrements
- [x] Run cron again — confirm no duplicate notifications are created
- [x] `npm test -- --coverage` passes with ≥ 80% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)