### PR TITLE
UI polish: confirm dialogs, toasts, and route skeletons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "19.2.3",
         "resend": "^6.9.2",
         "server-only": "^0.0.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -10963,6 +10964,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "19.2.3",
     "resend": "^6.9.2",
     "server-only": "^0.0.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/src/__tests__/components/confirm-dialog.test.tsx
+++ b/src/__tests__/components/confirm-dialog.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+
+function renderDialog(props: Partial<Parameters<typeof ConfirmDialog>[0]> = {}) {
+    const defaults = {
+        open: true,
+        onOpenChange: jest.fn(),
+        title: "Delete item?",
+        description: "This cannot be undone.",
+        onConfirm: jest.fn().mockResolvedValue(undefined),
+    };
+    return render(<ConfirmDialog {...defaults} {...props} />);
+}
+
+describe("ConfirmDialog", () => {
+    it("renders title and description", () => {
+        renderDialog();
+        expect(screen.getByText("Delete item?")).toBeInTheDocument();
+        expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
+    });
+
+    it("renders default confirm and cancel labels", () => {
+        renderDialog();
+        expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    });
+
+    it("renders custom confirm and cancel labels", () => {
+        renderDialog({ confirmLabel: "Delete", cancelLabel: "Keep" });
+        expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Keep" })).toBeInTheDocument();
+    });
+
+    it("calls onConfirm when confirm button is clicked", async () => {
+        const user = userEvent.setup();
+        const onConfirm = jest.fn().mockResolvedValue(undefined);
+        renderDialog({ onConfirm });
+
+        await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onOpenChange(false) on success", async () => {
+        const user = userEvent.setup();
+        const onOpenChange = jest.fn();
+        const onConfirm = jest.fn().mockResolvedValue(undefined);
+        renderDialog({ onOpenChange, onConfirm });
+
+        await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+        await waitFor(() => {
+            expect(onOpenChange).toHaveBeenCalledWith(false);
+        });
+    });
+
+    it("does not call onConfirm when cancel is clicked", async () => {
+        const user = userEvent.setup();
+        const onConfirm = jest.fn();
+        renderDialog({ onConfirm });
+
+        await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+        expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it("calls onOpenChange(false) when cancel is clicked", async () => {
+        const user = userEvent.setup();
+        const onOpenChange = jest.fn();
+        renderDialog({ onOpenChange });
+
+        await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("shows error text when onConfirm throws", async () => {
+        const user = userEvent.setup();
+        const onConfirm = jest.fn().mockRejectedValue(new Error("Server error"));
+        renderDialog({ onConfirm });
+
+        await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Server error")).toBeInTheDocument();
+        });
+    });
+
+    it("does not close when onConfirm throws", async () => {
+        const user = userEvent.setup();
+        const onOpenChange = jest.fn();
+        const onConfirm = jest.fn().mockRejectedValue(new Error("Server error"));
+        renderDialog({ onOpenChange, onConfirm });
+
+        await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Server error")).toBeInTheDocument();
+        });
+        expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
+
+    it("disables the confirm button while submitting", async () => {
+        const user = userEvent.setup();
+        let resolve: () => void;
+        const onConfirm = jest.fn(
+            () => new Promise<void>((res) => { resolve = res; })
+        );
+        renderDialog({ onConfirm });
+
+        await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+        expect(screen.getByRole("button", { name: /confirm\.\.\./i })).toBeDisabled();
+        resolve!();
+    });
+
+    it("does not render when open is false", () => {
+        renderDialog({ open: false });
+        expect(screen.queryByText("Delete item?")).not.toBeInTheDocument();
+    });
+});

--- a/src/__tests__/components/delete-dialogs-toast.test.tsx
+++ b/src/__tests__/components/delete-dialogs-toast.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DeleteWorkDialog } from "@/app/staff/delete-work-dialog";
+import { DeleteTagDialog } from "@/app/staff/delete-tag-dialog";
+
+const mockFetch = jest.fn();
+const mockToastSuccess = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("sonner", () => ({
+    toast: {
+        success: (...args: unknown[]) => mockToastSuccess(...args),
+    },
+}));
+
+beforeEach(() => {
+    mockFetch.mockClear();
+    mockToastSuccess.mockClear();
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+});
+
+describe("DeleteWorkDialog toast", () => {
+    it("toasts on successful delete", async () => {
+        const user = userEvent.setup();
+        const onDeleted = jest.fn();
+        render(
+            <DeleteWorkDialog
+                open={true}
+                onOpenChange={() => {}}
+                work={{ id: "w1", title: "My Book" }}
+                onDeleted={onDeleted}
+            />
+        );
+
+        await user.click(screen.getByRole("button", { name: /delete/i }));
+
+        await waitFor(() => {
+            expect(mockToastSuccess).toHaveBeenCalledWith('"My Book" deleted');
+        });
+    });
+
+    it("does not toast when delete fails", async () => {
+        const user = userEvent.setup();
+        mockFetch.mockResolvedValue({
+            ok: false,
+            json: async () => ({ error: "Work in use" }),
+        });
+        render(
+            <DeleteWorkDialog
+                open={true}
+                onOpenChange={() => {}}
+                work={{ id: "w1", title: "My Book" }}
+                onDeleted={jest.fn()}
+            />
+        );
+
+        await user.click(screen.getByRole("button", { name: /delete/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Work in use")).toBeInTheDocument();
+        });
+        expect(mockToastSuccess).not.toHaveBeenCalled();
+    });
+});
+
+describe("DeleteTagDialog toast", () => {
+    it("toasts on successful delete", async () => {
+        const user = userEvent.setup();
+        render(
+            <DeleteTagDialog
+                open={true}
+                onOpenChange={() => {}}
+                tag={{ id: "t1", name: "Fiction" }}
+                onDeleted={jest.fn()}
+            />
+        );
+
+        await user.click(screen.getByRole("button", { name: /delete/i }));
+
+        await waitFor(() => {
+            expect(mockToastSuccess).toHaveBeenCalledWith('Tag "Fiction" deleted');
+        });
+    });
+});

--- a/src/__tests__/components/hold-work-button.test.tsx
+++ b/src/__tests__/components/hold-work-button.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HoldWorkButton } from "@/app/works/[id]/hold-work-button";
+
+const mockRefresh = jest.fn();
+const mockFetch = jest.fn();
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+jest.mock("sonner", () => ({
+    toast: {
+        success: (...args: unknown[]) => mockToastSuccess(...args),
+        error: (...args: unknown[]) => mockToastError(...args),
+    },
+}));
+
+beforeEach(() => {
+    mockFetch.mockClear();
+    mockRefresh.mockClear();
+    mockToastSuccess.mockClear();
+    mockToastError.mockClear();
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+});
+
+describe("HoldWorkButton — none status", () => {
+    it("renders Request Hold button", () => {
+        render(<HoldWorkButton workId="w1" holdStatus="none" />);
+        expect(screen.getByRole("button", { name: /request hold/i })).toBeInTheDocument();
+    });
+
+    it("POSTs directly on click without a confirmation dialog", async () => {
+        const user = userEvent.setup();
+        render(<HoldWorkButton workId="w1" holdStatus="none" />);
+
+        await user.click(screen.getByRole("button", { name: /request hold/i }));
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith("/api/works/w1/hold", { method: "POST" });
+        });
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("shows a success toast on successful request", async () => {
+        const user = userEvent.setup();
+        render(<HoldWorkButton workId="w1" holdStatus="none" />);
+
+        await user.click(screen.getByRole("button", { name: /request hold/i }));
+
+        await waitFor(() => {
+            expect(mockToastSuccess).toHaveBeenCalledWith("Hold requested");
+        });
+    });
+
+    it("shows an error toast when request hold fails", async () => {
+        const user = userEvent.setup();
+        mockFetch.mockResolvedValue({
+            ok: false,
+            json: async () => ({ error: "Already on hold" }),
+        });
+        render(<HoldWorkButton workId="w1" holdStatus="none" />);
+
+        await user.click(screen.getByRole("button", { name: /request hold/i }));
+
+        await waitFor(() => {
+            expect(mockToastError).toHaveBeenCalledWith("Already on hold");
+        });
+    });
+});
+
+describe("HoldWorkButton — own status", () => {
+    it("renders Remove Hold button", () => {
+        render(<HoldWorkButton workId="w1" holdStatus="own" />);
+        expect(screen.getByRole("button", { name: /remove hold/i })).toBeInTheDocument();
+    });
+
+    it("opens confirmation dialog on click", async () => {
+        const user = userEvent.setup();
+        render(<HoldWorkButton workId="w1" holdStatus="own" />);
+
+        await user.click(screen.getByRole("button", { name: /remove hold/i }));
+
+        expect(screen.getByText("Remove hold?")).toBeInTheDocument();
+    });
+
+    it("does not fetch when cancel is clicked", async () => {
+        const user = userEvent.setup();
+        render(<HoldWorkButton workId="w1" holdStatus="own" />);
+
+        await user.click(screen.getByRole("button", { name: /remove hold/i }));
+        await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("DELETEs the hold when confirmed", async () => {
+        const user = userEvent.setup();
+        render(<HoldWorkButton workId="w1" holdStatus="own" />);
+
+        await user.click(screen.getByRole("button", { name: /remove hold/i }));
+        await user.click(screen.getByRole("button", { name: /^remove hold$/i }));
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith("/api/works/w1/hold", { method: "DELETE" });
+        });
+    });
+
+    it("shows a success toast after remove", async () => {
+        const user = userEvent.setup();
+        render(<HoldWorkButton workId="w1" holdStatus="own" />);
+
+        await user.click(screen.getByRole("button", { name: /remove hold/i }));
+        await user.click(screen.getByRole("button", { name: /^remove hold$/i }));
+
+        await waitFor(() => {
+            expect(mockToastSuccess).toHaveBeenCalledWith("Hold removed");
+        });
+    });
+
+    it("does not toast when DELETE fails", async () => {
+        const user = userEvent.setup();
+        mockFetch.mockResolvedValue({
+            ok: false,
+            json: async () => ({ error: "Hold not found" }),
+        });
+        render(<HoldWorkButton workId="w1" holdStatus="own" />);
+
+        await user.click(screen.getByRole("button", { name: /remove hold/i }));
+        await user.click(screen.getByRole("button", { name: /^remove hold$/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Hold not found")).toBeInTheDocument();
+        });
+        expect(mockToastSuccess).not.toHaveBeenCalled();
+    });
+
+    it("shows error in dialog when DELETE fails", async () => {
+        const user = userEvent.setup();
+        mockFetch.mockResolvedValue({
+            ok: false,
+            json: async () => ({ error: "Hold not found" }),
+        });
+        render(<HoldWorkButton workId="w1" holdStatus="own" />);
+
+        await user.click(screen.getByRole("button", { name: /remove hold/i }));
+        await user.click(screen.getByRole("button", { name: /^remove hold$/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Hold not found")).toBeInTheDocument();
+        });
+    });
+});
+
+describe("HoldWorkButton — other status", () => {
+    it("renders disabled On Hold button with holder name", () => {
+        render(<HoldWorkButton workId="w1" holdStatus="other" holdUserName="Jane" />);
+        const btn = screen.getByRole("button", { name: /on hold by jane/i });
+        expect(btn).toBeDisabled();
+    });
+});

--- a/src/__tests__/components/logout-button.test.tsx
+++ b/src/__tests__/components/logout-button.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LogoutButton } from "@/components/logout-button";
+
+const mockPush = jest.fn();
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({ push: mockPush }),
+}));
+
+beforeEach(() => {
+    mockFetch.mockClear();
+    mockPush.mockClear();
+    mockFetch.mockResolvedValue({ ok: true });
+});
+
+describe("LogoutButton", () => {
+    it("renders the sign out button", () => {
+        render(<LogoutButton />);
+        expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
+    });
+
+    it("opens the confirmation dialog when clicked", async () => {
+        const user = userEvent.setup();
+        render(<LogoutButton />);
+
+        await user.click(screen.getByRole("button", { name: /sign out/i }));
+
+        expect(screen.getByText("Sign out?")).toBeInTheDocument();
+        expect(screen.getByText(/returned to the sign-in page/i)).toBeInTheDocument();
+    });
+
+    it("does not fetch when cancel is clicked", async () => {
+        const user = userEvent.setup();
+        render(<LogoutButton />);
+
+        await user.click(screen.getByRole("button", { name: /sign out/i }));
+        await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("POSTs to /api/auth/logout when confirmed", async () => {
+        const user = userEvent.setup();
+        render(<LogoutButton />);
+
+        await user.click(screen.getByRole("button", { name: /sign out/i }));
+        await user.click(screen.getByRole("button", { name: /^sign out$/i }));
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith("/api/auth/logout", { method: "POST" });
+        });
+    });
+
+    it("redirects to /login after confirming", async () => {
+        const user = userEvent.setup();
+        render(<LogoutButton />);
+
+        await user.click(screen.getByRole("button", { name: /sign out/i }));
+        await user.click(screen.getByRole("button", { name: /^sign out$/i }));
+
+        await waitFor(() => {
+            expect(mockPush).toHaveBeenCalledWith("/login");
+        });
+    });
+});

--- a/src/__tests__/components/table-skeleton.test.tsx
+++ b/src/__tests__/components/table-skeleton.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { TableSkeleton } from "@/components/table-skeleton";
+
+describe("TableSkeleton", () => {
+    it("renders the default number of rows", () => {
+        const { container } = render(<TableSkeleton columns={3} />);
+        const bodyRows = container.querySelectorAll("tbody tr");
+        expect(bodyRows).toHaveLength(6);
+    });
+
+    it("renders the specified number of rows", () => {
+        const { container } = render(<TableSkeleton columns={3} rows={4} />);
+        const bodyRows = container.querySelectorAll("tbody tr");
+        expect(bodyRows).toHaveLength(4);
+    });
+
+    it("renders the correct number of cells per row matching columns", () => {
+        const { container } = render(<TableSkeleton columns={5} rows={2} />);
+        const rows = container.querySelectorAll("tbody tr");
+        rows.forEach((row) => {
+            expect(row.querySelectorAll("td")).toHaveLength(5);
+        });
+    });
+
+    it("renders header text when headers are provided", () => {
+        render(<TableSkeleton columns={2} headers={["Title", "Author"]} />);
+        expect(screen.getByText("Title")).toBeInTheDocument();
+        expect(screen.getByText("Author")).toBeInTheDocument();
+    });
+
+    it("applies animate-pulse class to skeleton cells", () => {
+        const { container } = render(<TableSkeleton columns={2} rows={1} />);
+        const pulsingElements = container.querySelectorAll(".animate-pulse");
+        expect(pulsingElements.length).toBeGreaterThan(0);
+    });
+});

--- a/src/app/admin/admin-users-client.tsx
+++ b/src/app/admin/admin-users-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -149,6 +150,7 @@ export function AdminUsersClient({
         setUsers((prev) =>
           prev.map((u) => (u.id === updated.id ? updated : u))
         );
+        toast.success(`User "${updated.name}" updated`);
       } else {
         const res = await fetch("/api/admin/users", {
           method: "POST",
@@ -164,6 +166,7 @@ export function AdminUsersClient({
 
         const created = await res.json();
         setUsers((prev) => [created, ...prev]);
+        toast.success(`User "${created.name}" created`);
       }
 
       setFormOpen(false);
@@ -188,8 +191,10 @@ export function AdminUsersClient({
         return;
       }
 
+      const deletedName = deletingUser.name;
       setUsers((prev) => prev.filter((u) => u.id !== deletingUser.id));
       setDeleteOpen(false);
+      toast.success(`User "${deletedName}" deleted`);
       router.refresh();
     } finally {
       setSubmitting(false);

--- a/src/app/admin/loading.tsx
+++ b/src/app/admin/loading.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { TableSkeleton } from "@/components/table-skeleton";
+
+export default function LoadingAdmin() {
+    return (
+        <div className="mx-auto max-w-7xl px-4 py-8">
+            <Skeleton className="h-8 w-48 mb-6" />
+            <div className="flex items-center gap-4 mb-4">
+                <Skeleton className="h-9 w-56" />
+                <Skeleton className="h-9 w-40" />
+            </div>
+            <TableSkeleton
+                columns={5}
+                headers={["Name", "Email", "Role", "Created", "Actions"]}
+            />
+        </div>
+    );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Toaster } from "sonner";
 import { Header } from "@/components/header";
 import "./globals.css";
 
@@ -30,6 +31,7 @@ export default async function RootLayout({
       >
         <Header />
         {children}
+        <Toaster position="bottom-right" richColors closeButton />
       </body>
     </html>
   );

--- a/src/app/search/loading.tsx
+++ b/src/app/search/loading.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function LoadingSearch() {
+    return (
+        <div className="mx-auto max-w-7xl px-4 py-8">
+            <Skeleton className="h-10 w-72 mb-2" />
+            <div className="mb-6" />
+
+            {/* Search bar */}
+            <div className="flex gap-2 mb-6">
+                <Skeleton className="h-10 flex-1 max-w-xl" />
+                <Skeleton className="h-10 w-24" />
+            </div>
+
+            {/* Filter row */}
+            <div className="flex flex-wrap gap-3 mb-6">
+                <Skeleton className="h-9 w-36" />
+                <Skeleton className="h-9 w-36" />
+                <Skeleton className="h-9 w-36" />
+                <Skeleton className="h-9 w-28" />
+            </div>
+
+            {/* Result cards grid */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {Array.from({ length: 6 }).map((_, i) => (
+                    <div key={i} className="border rounded-lg p-4 space-y-3">
+                        <Skeleton className="h-5 w-3/4" />
+                        <Skeleton className="h-4 w-1/2" />
+                        <Skeleton className="h-4 w-2/3" />
+                        <div className="flex gap-2 pt-1">
+                            <Skeleton className="h-5 w-16 rounded-full" />
+                            <Skeleton className="h-5 w-20 rounded-full" />
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/app/staff/checkout-form-dialog.tsx
+++ b/src/app/staff/checkout-form-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -99,6 +100,8 @@ export function CheckoutFormDialog({
                 return;
             }
 
+            const workTitle = availableWorks.find((w) => w.id === formData.work_id)?.title ?? "Item";
+            toast.success(`"${workTitle}" checked out`);
             onOpenChange(false);
             onCreated();
         } finally {

--- a/src/app/staff/delete-tag-dialog.tsx
+++ b/src/app/staff/delete-tag-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
     Dialog,
@@ -43,6 +44,7 @@ export function DeleteTagDialog({ open, onOpenChange, tag, onDeleted }: DeleteTa
                 return;
             }
 
+            toast.success(`Tag "${tag.name}" deleted`);
             onDeleted(tag.id);
             onOpenChange(false);
         } finally {

--- a/src/app/staff/delete-work-dialog.tsx
+++ b/src/app/staff/delete-work-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
     Dialog,
@@ -43,6 +44,7 @@ export function DeleteWorkDialog({ open, onOpenChange, work, onDeleted }: Delete
                 return;
             }
 
+            toast.success(`"${work.title}" deleted`);
             onDeleted(work.id);
             onOpenChange(false);
         } finally {

--- a/src/app/staff/loading.tsx
+++ b/src/app/staff/loading.tsx
@@ -1,0 +1,46 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { TableSkeleton } from "@/components/table-skeleton";
+
+export default function LoadingStaff() {
+    return (
+        <div className="mx-auto max-w-7xl px-4 py-8 space-y-10">
+            <section>
+                <Skeleton className="h-8 w-48 mb-6" />
+                <div className="flex items-center gap-4 mb-4">
+                    <Skeleton className="h-9 w-36" />
+                    <Skeleton className="h-9 w-64" />
+                </div>
+                <TableSkeleton
+                    columns={7}
+                    headers={["Title", "Publisher", "Call Number", "Date Published", "Pages", "Location", "Actions"]}
+                />
+            </section>
+
+            <section>
+                <Skeleton className="h-8 w-32 mb-6" />
+                <div className="flex items-center gap-4 mb-4">
+                    <Skeleton className="h-9 w-36" />
+                    <Skeleton className="h-9 w-64" />
+                    <Skeleton className="h-9 w-40" />
+                </div>
+                <TableSkeleton
+                    columns={6}
+                    headers={["Work", "Borrower", "Checked Out", "Due Date", "Status", "Actions"]}
+                />
+            </section>
+
+            <section>
+                <Skeleton className="h-8 w-16 mb-6" />
+                <div className="flex items-center gap-4 mb-4">
+                    <Skeleton className="h-9 w-28" />
+                    <Skeleton className="h-9 w-56" />
+                </div>
+                <TableSkeleton
+                    columns={3}
+                    headers={["Name", "Color", "Actions"]}
+                    rows={4}
+                />
+            </section>
+        </div>
+    );
+}

--- a/src/app/staff/return-checkout-dialog.tsx
+++ b/src/app/staff/return-checkout-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
     Dialog,
@@ -46,6 +47,7 @@ export function ReturnCheckoutDialog({ open, onOpenChange, checkout, onReturned 
                 return;
             }
 
+            toast.success(`"${checkout.work_title}" returned`);
             onOpenChange(false);
             onReturned();
         } finally {

--- a/src/app/staff/staff-checkouts-client.tsx
+++ b/src/app/staff/staff-checkouts-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -23,6 +24,7 @@ import {
 import { Search } from "lucide-react";
 import { CheckoutFormDialog } from "./checkout-form-dialog";
 import { ReturnCheckoutDialog } from "./return-checkout-dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 
 interface Checkout {
   id: string;
@@ -73,22 +75,35 @@ export function StaffCheckoutsClient({
     null,
   );
   const [loadingExtensionId, setLoadingExtensionId] = useState<string | null>(null);
+  const [rejectingCheckout, setRejectingCheckout] = useState<Checkout | null>(null);
 
-  const handleExtension = async (id: string, action: 'approve' | 'reject') => {
+  const handleApproveExtension = async (id: string) => {
     setLoadingExtensionId(id);
     try {
-      const res = await fetch(`/api/staff/checkouts/${id}/extend/${action}`, { method: 'POST' });
+      const res = await fetch(`/api/staff/checkouts/${id}/extend/approve`, { method: 'POST' });
       if (res.ok) {
+        toast.success("Extension approved");
         router.refresh();
       } else {
-        const data = await res.json();
-        alert(data.error || `Failed to ${action} extension`);
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error || "Failed to approve extension");
       }
     } catch (e: any) {
-      alert(e.message);
+      toast.error(e.message || "Failed to approve extension");
     } finally {
       setLoadingExtensionId(null);
     }
+  };
+
+  const handleRejectExtension = async () => {
+    if (!rejectingCheckout) return;
+    const res = await fetch(`/api/staff/checkouts/${rejectingCheckout.id}/extend/reject`, { method: 'POST' });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || "Failed to reject extension");
+    }
+    toast.success("Extension rejected");
+    router.refresh();
   };
 
   const checkedOutWorkIds = useMemo(() => {
@@ -242,7 +257,7 @@ export function StaffCheckoutsClient({
                           variant="default"
                           size="sm"
                           disabled={loadingExtensionId === checkout.id}
-                          onClick={() => handleExtension(checkout.id, 'approve')}
+                          onClick={() => handleApproveExtension(checkout.id)}
                         >
                           Approve Ext
                         </Button>
@@ -250,7 +265,7 @@ export function StaffCheckoutsClient({
                           variant="destructive"
                           size="sm"
                           disabled={loadingExtensionId === checkout.id}
-                          onClick={() => handleExtension(checkout.id, 'reject')}
+                          onClick={() => setRejectingCheckout(checkout)}
                         >
                           Reject
                         </Button>
@@ -277,6 +292,16 @@ export function StaffCheckoutsClient({
         onOpenChange={setReturnOpen}
         checkout={returningCheckout}
         onReturned={() => router.refresh()}
+      />
+
+      <ConfirmDialog
+        open={rejectingCheckout !== null}
+        onOpenChange={(open) => { if (!open) setRejectingCheckout(null); }}
+        title="Reject extension request?"
+        description="The borrower will keep their current due date."
+        confirmLabel="Reject"
+        destructive
+        onConfirm={handleRejectExtension}
       />
     </div>
   );

--- a/src/app/staff/tag-form-dialog.tsx
+++ b/src/app/staff/tag-form-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -82,6 +83,7 @@ export function TagFormDialog({ open, onOpenChange, editingTag, onSaved }: TagFo
                 }
 
                 const updated = await res.json();
+                toast.success(`Tag "${updated.name}" updated`);
                 onSaved(updated, false);
             } else {
                 const payload: Record<string, string | null> = { name: formData.name };
@@ -100,6 +102,7 @@ export function TagFormDialog({ open, onOpenChange, editingTag, onSaved }: TagFo
                 }
 
                 const created = await res.json();
+                toast.success(`Tag "${created.name}" created`);
                 onSaved(created, true);
             }
 

--- a/src/app/staff/work-form-dialog.tsx
+++ b/src/app/staff/work-form-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { toast } from "sonner";
 import { ScanBarcode, Search, Loader2, CheckCircle2, AlertCircle, ImagePlus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -235,6 +236,7 @@ export function WorkFormDialog({ open, onOpenChange, editingWork, onSaved, autoF
                 }
 
                 const updated = await res.json();
+                toast.success(`"${updated.title}" updated`);
                 onSaved(updated, false);
             } else {
                 const payload = coverBase64
@@ -253,6 +255,7 @@ export function WorkFormDialog({ open, onOpenChange, editingWork, onSaved, autoF
                 }
 
                 const created = await res.json();
+                toast.success(`"${created.title}" created`);
                 onSaved(created, true);
             }
 

--- a/src/app/staff/work-tags-editor.tsx
+++ b/src/app/staff/work-tags-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { Plus, X, Check } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -18,6 +19,7 @@ import {
     CommandItem,
     CommandList,
 } from "@/components/ui/command";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 
 interface Tag {
     id: string;
@@ -35,7 +37,7 @@ export function WorkTagsEditor({ workId, currentTags, allTags }: WorkTagsEditorP
     const router = useRouter();
     const [tags, setTags] = useState<Tag[]>(currentTags);
     const [popoverOpen, setPopoverOpen] = useState(false);
-    const [removing, setRemoving] = useState<string | null>(null);
+    const [pendingRemoval, setPendingRemoval] = useState<Tag | null>(null);
 
     const availableTags = allTags.filter(
         (t) => !tags.some((ct) => ct.id === t.id)
@@ -54,30 +56,35 @@ export function WorkTagsEditor({ workId, currentTags, allTags }: WorkTagsEditorP
                 const addedTag = allTags.find((t) => t.id === tagId);
                 if (addedTag) {
                     setTags((prev) => [...prev, addedTag]);
+                    toast.success(`Tag "${addedTag.name}" added`);
                 }
                 router.refresh();
+            } else {
+                const data = await res.json().catch(() => ({}));
+                toast.error(data.error || "Failed to add tag");
             }
         } catch {
-            // silently fail
+            toast.error("Failed to add tag");
         }
     }
 
-    async function handleRemove(tagId: string) {
-        setRemoving(tagId);
-        try {
-            const res = await fetch(`/api/staff/works/${workId}/tags`, {
-                method: "DELETE",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ tag_id: tagId }),
-            });
+    async function handleRemoveConfirmed() {
+        if (!pendingRemoval) return;
+        const res = await fetch(`/api/staff/works/${workId}/tags`, {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ tag_id: pendingRemoval.id }),
+        });
 
-            if (res.ok) {
-                setTags((prev) => prev.filter((t) => t.id !== tagId));
-                router.refresh();
-            }
-        } finally {
-            setRemoving(null);
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            throw new Error(data.error || "Failed to remove tag");
         }
+
+        const removedName = pendingRemoval.name;
+        setTags((prev) => prev.filter((t) => t.id !== pendingRemoval.id));
+        toast.success(`Tag "${removedName}" removed`);
+        router.refresh();
     }
 
     return (
@@ -91,8 +98,8 @@ export function WorkTagsEditor({ workId, currentTags, allTags }: WorkTagsEditorP
                     {tag.name}
                     <button
                         className="ml-1 rounded-full hover:bg-black/20 p-0.5 transition-colors"
-                        onClick={() => handleRemove(tag.id)}
-                        disabled={removing === tag.id}
+                        onClick={() => setPendingRemoval(tag)}
+                        aria-label={`Remove tag ${tag.name}`}
                     >
                         <X className="h-3 w-3" />
                     </button>
@@ -137,6 +144,15 @@ export function WorkTagsEditor({ workId, currentTags, allTags }: WorkTagsEditorP
                     </PopoverContent>
                 </Popover>
             )}
+            <ConfirmDialog
+                open={pendingRemoval !== null}
+                onOpenChange={(open) => { if (!open) setPendingRemoval(null); }}
+                title="Remove tag?"
+                description={`Remove "${pendingRemoval?.name}" from this work?`}
+                confirmLabel="Remove"
+                destructive
+                onConfirm={handleRemoveConfirmed}
+            />
         </>
     );
 }

--- a/src/app/works/[id]/hold-work-button.tsx
+++ b/src/app/works/[id]/hold-work-button.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { Hand } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 
 export interface HoldWorkButtonProps {
     workId: string;
@@ -14,6 +16,7 @@ export interface HoldWorkButtonProps {
 
 export function HoldWorkButton({ workId, holdStatus, holdUserName }: HoldWorkButtonProps) {
     const [loading, setLoading] = useState(false);
+    const [confirmOpen, setConfirmOpen] = useState(false);
     const router = useRouter();
 
     const handleRequestHold = async () => {
@@ -23,25 +26,29 @@ export function HoldWorkButton({ workId, holdStatus, holdUserName }: HoldWorkBut
                 method: "POST",
             });
             if (res.ok) {
+                toast.success("Hold requested");
                 router.refresh();
+            } else {
+                const data = await res.json().catch(() => ({}));
+                toast.error(data.error || "Failed to request hold");
             }
+        } catch {
+            toast.error("Failed to request hold");
         } finally {
             setLoading(false);
         }
     };
 
     const handleRemoveHold = async () => {
-        setLoading(true);
-        try {
-            const res = await fetch(`/api/works/${workId}/hold`, {
-                method: "DELETE",
-            });
-            if (res.ok) {
-                router.refresh();
-            }
-        } finally {
-            setLoading(false);
+        const res = await fetch(`/api/works/${workId}/hold`, {
+            method: "DELETE",
+        });
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            throw new Error(data.error || "Failed to remove hold");
         }
+        toast.success("Hold removed");
+        router.refresh();
     };
 
     if (holdStatus === "other") {
@@ -55,16 +62,27 @@ export function HoldWorkButton({ workId, holdStatus, holdUserName }: HoldWorkBut
 
     if (holdStatus === "own") {
         return (
-            <Button
-                size="sm"
-                variant="outline"
-                onClick={handleRemoveHold}
-                disabled={loading}
-                className="gap-2"
-            >
-                <Hand className="h-4 w-4" />
-                {loading ? "Removing..." : "Remove Hold"}
-            </Button>
+            <>
+                <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setConfirmOpen(true)}
+                    disabled={loading}
+                    className="gap-2"
+                >
+                    <Hand className="h-4 w-4" />
+                    Remove Hold
+                </Button>
+                <ConfirmDialog
+                    open={confirmOpen}
+                    onOpenChange={setConfirmOpen}
+                    title="Remove hold?"
+                    description="You can request this book again later."
+                    confirmLabel="Remove hold"
+                    destructive
+                    onConfirm={handleRemoveHold}
+                />
+            </>
         );
     }
 

--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ConfirmDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    title: string;
+    description: React.ReactNode;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    destructive?: boolean;
+    onConfirm: () => Promise<void> | void;
+}
+
+export function ConfirmDialog({
+    open,
+    onOpenChange,
+    title,
+    description,
+    confirmLabel = "Confirm",
+    cancelLabel = "Cancel",
+    destructive = false,
+    onConfirm,
+}: ConfirmDialogProps) {
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        if (open) setError("");
+    }, [open]);
+
+    async function handleConfirm() {
+        setSubmitting(true);
+        setError("");
+        try {
+            await onConfirm();
+            onOpenChange(false);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Something went wrong");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                    <DialogDescription>{description}</DialogDescription>
+                </DialogHeader>
+                {error && (
+                    <p className="text-sm text-destructive">{error}</p>
+                )}
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                        disabled={submitting}
+                    >
+                        {cancelLabel}
+                    </Button>
+                    <Button
+                        variant={destructive ? "destructive" : "default"}
+                        onClick={handleConfirm}
+                        disabled={submitting}
+                    >
+                        {submitting ? `${confirmLabel}...` : confirmLabel}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/logout-button.tsx
+++ b/src/components/logout-button.tsx
@@ -1,16 +1,32 @@
 "use client";
 
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 
 export function LogoutButton() {
-  async function handleLogout() {
-    await fetch("/api/auth/logout", { method: "POST" });
-    window.location.href = "/login";
-  }
+    const [open, setOpen] = useState(false);
+    const router = useRouter();
 
-  return (
-    <Button variant="ghost" size="sm" onClick={handleLogout}>
-      Sign Out
-    </Button>
-  );
+    async function handleLogout() {
+        await fetch("/api/auth/logout", { method: "POST" });
+        router.push("/login");
+    }
+
+    return (
+        <>
+            <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
+                Sign Out
+            </Button>
+            <ConfirmDialog
+                open={open}
+                onOpenChange={setOpen}
+                title="Sign out?"
+                description="You'll be returned to the sign-in page."
+                confirmLabel="Sign out"
+                onConfirm={handleLogout}
+            />
+        </>
+    );
 }

--- a/src/components/table-skeleton.tsx
+++ b/src/components/table-skeleton.tsx
@@ -1,0 +1,42 @@
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface TableSkeletonProps {
+    columns: number;
+    rows?: number;
+    headers?: string[];
+}
+
+export function TableSkeleton({ columns, rows = 6, headers }: TableSkeletonProps) {
+    return (
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    {Array.from({ length: columns }).map((_, i) => (
+                        <TableHead key={i}>
+                            {headers?.[i] ?? <Skeleton className="h-4 w-24" />}
+                        </TableHead>
+                    ))}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {Array.from({ length: rows }).map((_, rowIndex) => (
+                    <TableRow key={rowIndex}>
+                        {Array.from({ length: columns }).map((_, colIndex) => (
+                            <TableCell key={colIndex}>
+                                <Skeleton className="h-4 w-full" />
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="skeleton"
+            className={cn("animate-pulse rounded-md bg-muted", className)}
+            {...props}
+        />
+    );
+}
+
+export { Skeleton };


### PR DESCRIPTION
## Summary
- Adds a reusable `ConfirmDialog` and wires it into the four destructive spots that previously fired on a single click: sign out, remove hold, remove tag from a work, and reject extension request.
- Replaces silent failures and leftover `window.alert` calls with sonner toasts for both success and error feedback across staff dialogs, admin users, tag editor, and the hold flow.
- Adds route-level `loading.tsx` skeletons for `/staff`, `/admin`, and `/search` plus a shared `TableSkeleton` primitive so navigation no longer flashes a blank page.

## Test plan
- [ ] `npm test` — all existing + new component tests pass
- [ ] `npm test -- --coverage` — line coverage stays ≥ 80%
- [ ] Manually sign out, remove a hold, remove a tag, and reject an extension — confirm cancel closes the dialog and confirm fires the request
- [ ] Force an API error on reject extension and verify it renders inline in the dialog (not as `window.alert`)
- [ ] Hard-reload `/staff`, `/admin`, `/search` on throttled network and verify the skeleton shimmer appears before real content
- [ ] `grep -rn 'alert(' src/app` returns no results