### PR TITLE
fix: replace ellipsis dropdowns with edit/delete icon buttons

### DIFF
--- a/src/app/admin/admin-users-client.tsx
+++ b/src/app/admin/admin-users-client.tsx
@@ -30,13 +30,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Search } from "lucide-react";
+import { Search, Pencil, Trash2 } from "lucide-react";
 
 interface User {
   id: string;
@@ -267,25 +261,14 @@ export function AdminUsersClient({
                   {new Date(user.created_at).toLocaleDateString()}
                 </TableCell>
                 <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="sm">
-                        ...
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={() => openEditDialog(user)}>
-                        Edit
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => openDeleteDialog(user)}
-                        disabled={isSelf(user.id)}
-                        className="text-destructive"
-                      >
-                        Delete
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                  <div className="flex gap-1">
+                    <Button variant="ghost" size="sm" onClick={() => openEditDialog(user)}>
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="sm" className="text-destructive" onClick={() => openDeleteDialog(user)} disabled={isSelf(user.id)}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
                 </TableCell>
               </TableRow>
             ))

--- a/src/app/staff/staff-tags-client.tsx
+++ b/src/app/staff/staff-tags-client.tsx
@@ -12,12 +12,7 @@ import {
     TableHeader,
     TableRow,
 } from "@/components/ui/table";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { Pencil, Trash2 } from "lucide-react";
 import { Search } from "lucide-react";
 import { TagFormDialog } from "./tag-form-dialog";
 import { DeleteTagDialog } from "./delete-tag-dialog";
@@ -132,24 +127,14 @@ export function StaffTagsClient({ initialTags }: StaffTagsClientProps) {
                                     )}
                                 </TableCell>
                                 <TableCell>
-                                    <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                            <Button variant="ghost" size="sm">
-                                                ...
-                                            </Button>
-                                        </DropdownMenuTrigger>
-                                        <DropdownMenuContent align="end">
-                                            <DropdownMenuItem onClick={() => openEditDialog(tag)}>
-                                                Edit
-                                            </DropdownMenuItem>
-                                            <DropdownMenuItem
-                                                onClick={() => openDeleteDialog(tag)}
-                                                className="text-destructive"
-                                            >
-                                                Delete
-                                            </DropdownMenuItem>
-                                        </DropdownMenuContent>
-                                    </DropdownMenu>
+                                    <div className="flex gap-1">
+                                        <Button variant="ghost" size="sm" onClick={() => openEditDialog(tag)}>
+                                            <Pencil className="h-4 w-4" />
+                                        </Button>
+                                        <Button variant="ghost" size="sm" className="text-destructive" onClick={() => openDeleteDialog(tag)}>
+                                            <Trash2 className="h-4 w-4" />
+                                        </Button>
+                                    </div>
                                 </TableCell>
                             </TableRow>
                         ))

--- a/src/app/staff/staff-works-client.tsx
+++ b/src/app/staff/staff-works-client.tsx
@@ -19,13 +19,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Search, Upload, Download, FileSpreadsheet } from "lucide-react";
+import { Search, Upload, Download, FileSpreadsheet, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { WorkFormDialog } from "./work-form-dialog";
 import { DeleteWorkDialog } from "./delete-work-dialog";
@@ -308,24 +302,14 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
                                 <TableCell>{work.number_of_pages ?? "—"}</TableCell>
                                 <TableCell>{work.location ?? "—"}</TableCell>
                                 <TableCell onClick={(e) => e.stopPropagation()}>
-                                    <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                            <Button variant="ghost" size="sm">
-                                                ...
-                                            </Button>
-                                        </DropdownMenuTrigger>
-                                        <DropdownMenuContent align="end">
-                                            <DropdownMenuItem onClick={() => openEditDialog(work)}>
-                                                Edit
-                                            </DropdownMenuItem>
-                                            <DropdownMenuItem
-                                                onClick={() => openDeleteDialog(work)}
-                                                className="text-destructive"
-                                            >
-                                                Delete
-                                            </DropdownMenuItem>
-                                        </DropdownMenuContent>
-                                    </DropdownMenu>
+                                    <div className="flex gap-1">
+                                        <Button variant="ghost" size="sm" onClick={() => openEditDialog(work)}>
+                                            <Pencil className="h-4 w-4" />
+                                        </Button>
+                                        <Button variant="ghost" size="sm" className="text-destructive" onClick={() => openDeleteDialog(work)}>
+                                            <Trash2 className="h-4 w-4" />
+                                        </Button>
+                                    </div>
                                 </TableCell>
                             </TableRow>
                         ))


### PR DESCRIPTION
## Summary
- Replaces hidden `...` dropdown menus with visible `Pencil` and `Trash2` icon buttons in staff works, staff tags, and admin users tables
- Action logic (`openEditDialog`, `openDeleteDialog`) is unchanged
- Self-delete guard (`disabled={isSelf(...)}`) preserved on the users table

Closes #45