### PR TITLE
feat: add server-side pagination to list endpoints

### DIFF
--- a/src/__tests__/api/admin/users.test.ts
+++ b/src/__tests__/api/admin/users.test.ts
@@ -47,34 +47,61 @@ beforeEach(() => {
   mockHashPassword.mockResolvedValue("hashed-password");
 });
 
+function makeGetRequest(qs = ""): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/admin/users${qs}`, {
+    method: "GET",
+  });
+}
+
 describe("GET /api/admin/users", () => {
   it("returns 401 when not authenticated", async () => {
     mockGetCurrentUser.mockResolvedValue(null);
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(401);
   });
 
   it("returns 403 when not admin", async () => {
     mockGetCurrentUser.mockResolvedValue({ ...adminUser, role: "user" });
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(403);
   });
 
-  it("returns all users", async () => {
+  it("returns paginated users", async () => {
     const users = [
-      { id: "1", email: "a@b.com", name: "A", role: "admin" },
-      { id: "2", email: "c@d.com", name: "C", role: "user" },
+      { id: "1", email: "a@b.com", name: "A", role: "admin", total_count: "2" },
+      { id: "2", email: "c@d.com", name: "C", role: "user", total_count: "2" },
     ];
     mockQuery.mockResolvedValue({ rows: users });
 
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual(users);
+    expect(body).toEqual({
+      items: [
+        { id: "1", email: "a@b.com", name: "A", role: "admin" },
+        { id: "2", email: "c@d.com", name: "C", role: "user" },
+      ],
+      total: 2,
+      page: 1,
+      pageSize: 20,
+    });
     expect(mockQuery).toHaveBeenCalledWith(
-      expect.stringContaining("SELECT"),
-      undefined
+      expect.stringContaining("LIMIT $1 OFFSET $2"),
+      [20, 0]
+    );
+  });
+
+  it("applies page and pageSize query params", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const res = await GET(makeGetRequest("?page=2&pageSize=10"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ items: [], total: 0, page: 2, pageSize: 10 });
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("LIMIT"),
+      [10, 10]
     );
   });
 });
@@ -309,7 +336,7 @@ describe("Forbidden access tests (admin)", () => {
   });
 
   it("GET /api/admin/users returns 403 for non-admin", async () => {
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(403);
   });
 
@@ -334,7 +361,7 @@ describe("Forbidden access tests (admin)", () => {
 describe("500 error handling (admin)", () => {
   it("GET /api/admin/users returns 500 on unexpected error", async () => {
     mockGetCurrentUser.mockRejectedValue("unexpected");
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(500);
   });
 

--- a/src/__tests__/api/search/search-popular.test.ts
+++ b/src/__tests__/api/search/search-popular.test.ts
@@ -22,18 +22,22 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
-// Helper: first call returns popular works, second returns tags
 function mockPopularWithTags(
     works: Record<string, unknown>[],
     tagRows: Record<string, unknown>[] = []
 ) {
-    mockQuery
-        .mockResolvedValueOnce({ rows: works })   // getPopularWorks
-        .mockResolvedValueOnce({ rows: tagRows }); // getTagsForWorks
+    const worksWithCount = works.map((w) => ({
+        ...w,
+        total_count: String(works.length),
+    }));
+    mockQuery.mockResolvedValueOnce({ rows: worksWithCount });
+    if (works.length > 0) {
+        mockQuery.mockResolvedValueOnce({ rows: tagRows });
+    }
 }
 
 describe("GET /api/search/popular", () => {
-    it("returns popular works with checkout counts and tags", async () => {
+    it("returns paginated popular works with default pageSize 25", async () => {
         const works = [
             { id: "1", title: "Popular Book", checkout_count: 10 },
             { id: "2", title: "Less Popular", checkout_count: 3 },
@@ -44,13 +48,18 @@ describe("GET /api/search/popular", () => {
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toEqual([
-            { id: "1", title: "Popular Book", checkout_count: 10, tags: [] },
-            { id: "2", title: "Less Popular", checkout_count: 3, tags: [] },
-        ]);
+        expect(body).toEqual({
+            items: [
+                { id: "1", title: "Popular Book", checkout_count: 10, tags: [] },
+                { id: "2", title: "Less Popular", checkout_count: 3, tags: [] },
+            ],
+            total: 2,
+            page: 1,
+            pageSize: 25,
+        });
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("COALESCE(COUNT(c.id)"),
-            undefined
+            expect.stringContaining("LIMIT $1 OFFSET $2"),
+            [25, 0]
         );
     });
 
@@ -65,33 +74,45 @@ describe("GET /api/search/popular", () => {
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body[0].tags).toEqual([
+        expect(body.items[0].tags).toEqual([
             { id: "t1", name: "Fiction", color: "#ff0000", created_at: "x", updated_at: "x" },
         ]);
     });
 
-    it("passes tag filter to getPopularWorks when tag param is set", async () => {
+    it("passes tag filter with pagination params", async () => {
         mockPopularWithTags([{ id: "1", title: "Tagged Popular", checkout_count: 7 }]);
 
         const res = await GET(makeRequest({ tag: "tag-uuid-1" }));
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toHaveLength(1);
+        expect(body.items).toHaveLength(1);
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("JOIN work_tags"),
-            ["tag-uuid-1"]
+            ["tag-uuid-1", 25, 0]
         );
     });
 
-    it("returns empty array when no works are popular", async () => {
+    it("applies page and pageSize params", async () => {
+        mockPopularWithTags([]);
+
+        await GET(makeRequest({ page: "2", pageSize: "10" }));
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("LIMIT $1 OFFSET $2"),
+            [10, 10]
+        );
+    });
+
+    it("returns empty items when no works are popular", async () => {
         mockPopularWithTags([]);
 
         const res = await GET(makeRequest());
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toEqual([]);
+        expect(body.items).toEqual([]);
+        expect(body.total).toBe(0);
     });
 
     it("trims whitespace from tag param", async () => {
@@ -101,7 +122,7 @@ describe("GET /api/search/popular", () => {
 
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("JOIN work_tags"),
-            ["tag-uuid-1"]
+            ["tag-uuid-1", 25, 0]
         );
     });
 
@@ -112,7 +133,7 @@ describe("GET /api/search/popular", () => {
 
         expect(mockQuery).toHaveBeenCalledWith(
             expect.not.stringContaining("JOIN work_tags"),
-            undefined
+            [25, 0]
         );
     });
 });

--- a/src/__tests__/api/search/search-works.test.ts
+++ b/src/__tests__/api/search/search-works.test.ts
@@ -22,29 +22,34 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
-// Helper: first call returns works, second returns author rows, third tags, fourth ratings
+// Query call order:
+// 1. Main paginated search (SELECT ... LIMIT ... OFFSET)
+// 2. attachAuthorsToWorks (FROM work_authors) — only if main returned rows
+// 3. Distinct languages (SELECT DISTINCT w.language)
+// 4. getTagsForWorks
+// 5. getWorkRatingSummaries
 function mockSearchWithTags(
     works: Record<string, unknown>[],
     tagRows: Record<string, unknown>[] = [],
-    ratingRows: Record<string, unknown>[] = []
+    ratingRows: Record<string, unknown>[] = [],
+    languages: { language: string }[] = []
 ) {
-    if (works.length === 0) {
-        // attachAuthorsToWorks short-circuits on empty input
+    const worksWithCount = works.map((w) => ({ ...w, total_count: String(works.length) }));
+    mockQuery.mockResolvedValueOnce({ rows: worksWithCount });
+    if (works.length > 0) {
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // attachAuthorsToWorks
+    }
+    mockQuery.mockResolvedValueOnce({ rows: languages });
+    if (works.length > 0) {
+        // getTagsForWorks and getWorkRatingSummaries early-return on empty workIds
         mockQuery
-            .mockResolvedValueOnce({ rows: works })
-            .mockResolvedValueOnce({ rows: tagRows })
-            .mockResolvedValueOnce({ rows: ratingRows });
-    } else {
-        mockQuery
-            .mockResolvedValueOnce({ rows: works })
-            .mockResolvedValueOnce({ rows: [] })      // attachAuthorsToWorks
             .mockResolvedValueOnce({ rows: tagRows })
             .mockResolvedValueOnce({ rows: ratingRows });
     }
 }
 
 describe("GET /api/search/works", () => {
-    it("returns all works with tags when no query params", async () => {
+    it("returns paginated works with tags and default pageSize 25", async () => {
         const works = [
             { id: "1", title: "Book A" },
             { id: "2", title: "Book B" },
@@ -55,13 +60,19 @@ describe("GET /api/search/works", () => {
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toEqual([
-            { id: "1", title: "Book A", authors: [], tags: [], average_rating: null, rating_count: 0 },
-            { id: "2", title: "Book B", authors: [], tags: [], average_rating: null, rating_count: 0 },
-        ]);
+        expect(body).toEqual({
+            items: [
+                { id: "1", title: "Book A", authors: [], tags: [], average_rating: null, rating_count: 0 },
+                { id: "2", title: "Book B", authors: [], tags: [], average_rating: null, rating_count: 0 },
+            ],
+            total: 2,
+            page: 1,
+            pageSize: 25,
+            languages: [],
+        });
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("SELECT"),
-            undefined
+            expect.stringContaining("LIMIT $1 OFFSET $2"),
+            [25, 0]
         );
     });
 
@@ -76,7 +87,7 @@ describe("GET /api/search/works", () => {
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body[0].tags).toEqual([
+        expect(body.items[0].tags).toEqual([
             { id: "t1", name: "Fiction", color: "#ff0000", created_at: "x", updated_at: "x" },
         ]);
     });
@@ -88,10 +99,10 @@ describe("GET /api/search/works", () => {
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toHaveLength(1);
+        expect(body.items).toHaveLength(1);
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("ILIKE"),
-            ["%gatsby%"]
+            ["%gatsby%", 25, 0]
         );
     });
 
@@ -102,10 +113,10 @@ describe("GET /api/search/works", () => {
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toHaveLength(1);
+        expect(body.items).toHaveLength(1);
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("w.media_type = $1"),
-            ["ebook"]
+            ["ebook", 25, 0]
         );
     });
 
@@ -116,39 +127,83 @@ describe("GET /api/search/works", () => {
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toHaveLength(1);
+        expect(body.items).toHaveLength(1);
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("JOIN work_tags"),
-            ["tag-uuid-1"]
+            ["tag-uuid-1", 25, 0]
         );
     });
 
-    it("combines search query and media type filter", async () => {
-        mockSearchWithTags([]);
+    it("filters by language", async () => {
+        mockSearchWithTags([{ id: "1", title: "Livre" }]);
 
-        const res = await GET(makeRequest({ q: "history", media_type: "book" }));
+        const res = await GET(makeRequest({ lang: "French" }));
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toEqual([]);
+        expect(body.items).toHaveLength(1);
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("ILIKE"),
-            ["%history%", "book"]
-        );
-        expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("w.media_type = $2"),
-            ["%history%", "book"]
+            expect.stringContaining("w.language = $1"),
+            ["French", 25, 0]
         );
     });
 
-    it("returns empty array when no matches", async () => {
+    it("applies sort and direction server-side", async () => {
+        mockSearchWithTags([]);
+
+        await GET(makeRequest({ sort: "date_published", dir: "desc" }));
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("ORDER BY w.date_published DESC"),
+            [25, 0]
+        );
+    });
+
+    it("ignores disallowed sort values and falls back to title asc", async () => {
+        mockSearchWithTags([]);
+
+        await GET(makeRequest({ sort: "password_hash; DROP TABLE users" }));
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("ORDER BY w.title ASC"),
+            [25, 0]
+        );
+    });
+
+    it("applies page and pageSize params", async () => {
+        mockSearchWithTags([]);
+
+        await GET(makeRequest({ page: "3", pageSize: "10" }));
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("LIMIT $1 OFFSET $2"),
+            [10, 20]
+        );
+    });
+
+    it("returns distinct languages from result set", async () => {
+        mockSearchWithTags(
+            [{ id: "1", title: "x" }],
+            [],
+            [],
+            [{ language: "English" }, { language: "Spanish" }]
+        );
+
+        const res = await GET(makeRequest());
+        const body = await res.json();
+
+        expect(body.languages).toEqual(["English", "Spanish"]);
+    });
+
+    it("returns empty items when no matches", async () => {
         mockSearchWithTags([]);
 
         const res = await GET(makeRequest({ q: "nonexistent" }));
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toEqual([]);
+        expect(body.items).toEqual([]);
+        expect(body.total).toBe(0);
     });
 
     it("trims whitespace from query params", async () => {
@@ -158,7 +213,7 @@ describe("GET /api/search/works", () => {
 
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("ILIKE"),
-            ["%gatsby%"]
+            ["%gatsby%", 25, 0]
         );
     });
 
@@ -169,7 +224,7 @@ describe("GET /api/search/works", () => {
 
         expect(mockQuery).toHaveBeenCalledWith(
             expect.not.stringContaining("ILIKE"),
-            undefined
+            [25, 0]
         );
     });
 });

--- a/src/__tests__/api/staff/checkouts.test.ts
+++ b/src/__tests__/api/staff/checkouts.test.ts
@@ -56,34 +56,61 @@ beforeEach(() => {
 
 // ─── GET /api/staff/checkouts ───────────────────────────────────────
 
+function makeGetRequest(qs = ""): NextRequest {
+    return new NextRequest(`http://localhost:3000/api/staff/checkouts${qs}`, {
+        method: "GET",
+    });
+}
+
 describe("GET /api/staff/checkouts", () => {
     it("returns 401 when not authenticated", async () => {
         mockGetCurrentUser.mockResolvedValue(null);
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         expect(res.status).toBe(401);
     });
 
     it("returns 403 when user role is user", async () => {
         mockGetCurrentUser.mockResolvedValue({ ...staffUser, role: "user" });
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         expect(res.status).toBe(403);
     });
 
-    it("returns all checkouts for staff", async () => {
+    it("returns paginated checkouts for staff", async () => {
         const checkouts = [
-            { id: "c1", work_title: "Book A", user_name: "Alice" },
-            { id: "c2", work_title: "Book B", user_name: "Bob" },
+            { id: "c1", work_title: "Book A", user_name: "Alice", total_count: "2" },
+            { id: "c2", work_title: "Book B", user_name: "Bob", total_count: "2" },
         ];
         mockQuery.mockResolvedValue({ rows: checkouts });
 
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toEqual(checkouts);
+        expect(body).toEqual({
+            items: [
+                { id: "c1", work_title: "Book A", user_name: "Alice" },
+                { id: "c2", work_title: "Book B", user_name: "Bob" },
+            ],
+            total: 2,
+            page: 1,
+            pageSize: 20,
+        });
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("SELECT"),
-            undefined
+            expect.stringContaining("LIMIT $1 OFFSET $2"),
+            [20, 0]
+        );
+    });
+
+    it("applies page and pageSize query params", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+        const res = await GET(makeGetRequest("?page=2&pageSize=5"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual({ items: [], total: 0, page: 2, pageSize: 5 });
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("LIMIT"),
+            [5, 5]
         );
     });
 
@@ -91,7 +118,7 @@ describe("GET /api/staff/checkouts", () => {
         mockGetCurrentUser.mockResolvedValue(adminUser);
         mockQuery.mockResolvedValue({ rows: [] });
 
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         expect(res.status).toBe(200);
     });
 });
@@ -305,7 +332,7 @@ describe("Forbidden access tests (checkouts)", () => {
     });
 
     it("GET /api/staff/checkouts returns 403 for non-staff", async () => {
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         expect(res.status).toBe(403);
     });
 
@@ -339,7 +366,7 @@ describe("Forbidden access tests (checkouts)", () => {
 describe("500 error handling (checkouts)", () => {
     it("GET /api/staff/checkouts returns 500 on unexpected error", async () => {
         mockGetCurrentUser.mockRejectedValue("unexpected");
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         expect(res.status).toBe(500);
     });
 

--- a/src/__tests__/api/staff/works.test.ts
+++ b/src/__tests__/api/staff/works.test.ts
@@ -56,48 +56,72 @@ beforeEach(() => {
 
 // ─── GET /api/staff/works ────────────────────────────────────────────
 
+function makeGetRequest(qs = ""): NextRequest {
+    return new NextRequest(`http://localhost:3000/api/staff/works${qs}`, {
+        method: "GET",
+    });
+}
+
 describe("GET /api/staff/works", () => {
     it("returns 401 when not authenticated", async () => {
         mockGetCurrentUser.mockResolvedValue(null);
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         expect(res.status).toBe(401);
     });
 
     it("returns 403 when user role is user", async () => {
         mockGetCurrentUser.mockResolvedValue({ ...staffUser, role: "user" });
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         expect(res.status).toBe(403);
     });
 
-    it("returns all works for staff", async () => {
+    it("returns paginated works for staff", async () => {
         const works = [
-            { id: 1, title: "Work A" },
-            { id: 2, title: "Work B" },
+            { id: 1, title: "Work A", total_count: "2" },
+            { id: 2, title: "Work B", total_count: "2" },
         ];
         mockQuery.mockImplementation((text: string) => {
             if (text.includes("FROM work_authors")) return Promise.resolve({ rows: [] });
             return Promise.resolve({ rows: works });
         });
 
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         const body = await res.json();
 
         expect(res.status).toBe(200);
-        expect(body).toEqual([
-            { id: 1, title: "Work A", authors: [] },
-            { id: 2, title: "Work B", authors: [] },
-        ]);
+        expect(body).toEqual({
+            items: [
+                { id: 1, title: "Work A", authors: [] },
+                { id: 2, title: "Work B", authors: [] },
+            ],
+            total: 2,
+            page: 1,
+            pageSize: 20,
+        });
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("SELECT"),
-            undefined
+            expect.stringContaining("LIMIT $1 OFFSET $2"),
+            [20, 0]
         );
     });
 
-    it("returns all works for admin", async () => {
+    it("applies page and pageSize query params", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+        const res = await GET(makeGetRequest("?page=3&pageSize=10"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual({ items: [], total: 0, page: 3, pageSize: 10 });
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("LIMIT"),
+            [10, 20]
+        );
+    });
+
+    it("returns works for admin", async () => {
         mockGetCurrentUser.mockResolvedValue(adminUser);
         mockQuery.mockResolvedValue({ rows: [] });
 
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         expect(res.status).toBe(200);
     });
 });
@@ -314,7 +338,7 @@ describe("Forbidden access tests", () => {
     });
 
     it("GET /api/staff/works returns 403 for non-staff", async () => {
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         expect(res.status).toBe(403);
     });
 
@@ -350,7 +374,7 @@ describe("Forbidden access tests", () => {
 describe("500 error handling", () => {
     it("GET /api/staff/works returns 500 on unexpected error", async () => {
         mockGetCurrentUser.mockRejectedValue("unexpected");
-        const res = await GET();
+        const res = await GET(makeGetRequest());
         expect(res.status).toBe(500);
     });
 

--- a/src/__tests__/components/pagination-controls.test.tsx
+++ b/src/__tests__/components/pagination-controls.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PaginationControls } from "@/components/pagination-controls";
+
+describe("PaginationControls", () => {
+    it("renders nothing when total is zero", () => {
+        const { container } = render(
+            <PaginationControls
+                page={1}
+                pageSize={20}
+                total={0}
+                onPageChange={jest.fn()}
+            />
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it("renders nothing when total <= pageSize (single page)", () => {
+        const { container } = render(
+            <PaginationControls
+                page={1}
+                pageSize={20}
+                total={15}
+                onPageChange={jest.fn()}
+            />
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it("disables Previous on page 1", () => {
+        render(
+            <PaginationControls
+                page={1}
+                pageSize={20}
+                total={100}
+                onPageChange={jest.fn()}
+            />
+        );
+        expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled();
+    });
+
+    it("disables Next on last page", () => {
+        render(
+            <PaginationControls
+                page={5}
+                pageSize={20}
+                total={100}
+                onPageChange={jest.fn()}
+            />
+        );
+        expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
+    });
+
+    it("calls onPageChange with next page when Next clicked", () => {
+        const onPageChange = jest.fn();
+        render(
+            <PaginationControls
+                page={2}
+                pageSize={20}
+                total={100}
+                onPageChange={onPageChange}
+            />
+        );
+        fireEvent.click(screen.getByRole("button", { name: /next/i }));
+        expect(onPageChange).toHaveBeenCalledWith(3);
+    });
+
+    it("calls onPageChange with previous page when Previous clicked", () => {
+        const onPageChange = jest.fn();
+        render(
+            <PaginationControls
+                page={3}
+                pageSize={20}
+                total={100}
+                onPageChange={onPageChange}
+            />
+        );
+        fireEvent.click(screen.getByRole("button", { name: /previous/i }));
+        expect(onPageChange).toHaveBeenCalledWith(2);
+    });
+
+    it("renders numbered page buttons and jumps when clicked", () => {
+        const onPageChange = jest.fn();
+        render(
+            <PaginationControls
+                page={1}
+                pageSize={20}
+                total={60}
+                onPageChange={onPageChange}
+            />
+        );
+        fireEvent.click(screen.getByRole("button", { name: "3" }));
+        expect(onPageChange).toHaveBeenCalledWith(3);
+    });
+
+    it("marks current page button as active (aria-current)", () => {
+        render(
+            <PaginationControls
+                page={2}
+                pageSize={20}
+                total={100}
+                onPageChange={jest.fn()}
+            />
+        );
+        expect(screen.getByRole("button", { name: "2" })).toHaveAttribute(
+            "aria-current",
+            "page"
+        );
+    });
+});

--- a/src/__tests__/lib/data/checkouts.test.ts
+++ b/src/__tests__/lib/data/checkouts.test.ts
@@ -62,51 +62,55 @@ beforeEach(() => {
 
 // ─── getAllCheckouts ─────────────────────────────────────────────────
 
+const PAGE = { page: 1, pageSize: 20, offset: 0 };
+
 describe("getAllCheckouts", () => {
     it("throws Unauthorized when not authenticated", async () => {
         mockGetCurrentUser.mockResolvedValue(null);
-        await expect(getAllCheckouts()).rejects.toThrow("Unauthorized");
+        await expect(getAllCheckouts(PAGE)).rejects.toThrow("Unauthorized");
     });
 
     it("throws Forbidden when role is user", async () => {
         mockGetCurrentUser.mockResolvedValue(regularUser);
-        await expect(getAllCheckouts()).rejects.toThrow("Forbidden");
+        await expect(getAllCheckouts(PAGE)).rejects.toThrow("Forbidden");
     });
 
     it("allows admin users", async () => {
         mockGetCurrentUser.mockResolvedValue(adminUser);
         mockQuery.mockResolvedValue({ rows: [] });
-        await expect(getAllCheckouts()).resolves.toEqual([]);
+        await expect(getAllCheckouts(PAGE)).resolves.toEqual({ rows: [], total: 0 });
     });
 
-    it("returns all checkouts with joined data", async () => {
+    it("returns paginated checkouts with joined data and total", async () => {
         const checkouts = [
-            { id: "c1", work_title: "Book A", user_name: "Alice" },
-            { id: "c2", work_title: "Book B", user_name: "Bob" },
+            { id: "c1", work_title: "Book A", user_name: "Alice", total_count: "2" },
+            { id: "c2", work_title: "Book B", user_name: "Bob", total_count: "2" },
         ];
         mockQuery.mockResolvedValue({ rows: checkouts });
 
-        const result = await getAllCheckouts();
+        const result = await getAllCheckouts(PAGE);
 
-        expect(result).toEqual(checkouts);
+        expect(result).toEqual({
+            rows: [
+                { id: "c1", work_title: "Book A", user_name: "Alice" },
+                { id: "c2", work_title: "Book B", user_name: "Bob" },
+            ],
+            total: 2,
+        });
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("JOIN works"),
-            undefined
+            expect.stringContaining("LIMIT $1 OFFSET $2"),
+            [20, 0]
         );
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("JOIN users"),
-            undefined
-        );
-        expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("ORDER BY c.created_at DESC"),
-            undefined
+            expect.stringContaining("COUNT(*) OVER()"),
+            [20, 0]
         );
     });
 
-    it("returns an empty array when no checkouts exist", async () => {
+    it("returns empty rows and zero total when no checkouts exist", async () => {
         mockQuery.mockResolvedValue({ rows: [] });
-        const result = await getAllCheckouts();
-        expect(result).toEqual([]);
+        const result = await getAllCheckouts(PAGE);
+        expect(result).toEqual({ rows: [], total: 0 });
     });
 });
 
@@ -512,60 +516,62 @@ describe("markOverdueNotified", () => {
 
 // ─── getPopularWorks ────────────────────────────────────────────────
 
+const POP_PAGE = { page: 1, pageSize: 25, offset: 0 };
+
 describe("getPopularWorks", () => {
-    it("returns works ordered by checkout count descending", async () => {
+    it("returns paginated works ordered by checkout count descending", async () => {
         const works = [
-            { id: "w1", title: "Popular Book", checkout_count: 10 },
-            { id: "w2", title: "Less Popular", checkout_count: 3 },
+            { id: "w1", title: "Popular Book", checkout_count: 10, total_count: "2" },
+            { id: "w2", title: "Less Popular", checkout_count: 3, total_count: "2" },
         ];
         mockQuery.mockResolvedValue({ rows: works });
 
-        const result = await getPopularWorks();
+        const result = await getPopularWorks(POP_PAGE);
 
-        expect(result).toEqual(works);
-        expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("COALESCE(COUNT(c.id)"),
-            undefined
-        );
+        expect(result).toEqual({
+            rows: [
+                { id: "w1", title: "Popular Book", checkout_count: 10 },
+                { id: "w2", title: "Less Popular", checkout_count: 3 },
+            ],
+            total: 2,
+        });
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("ORDER BY checkout_count DESC"),
-            undefined
+            [25, 0]
         );
     });
 
     it("filters by tag when tagId is provided", async () => {
         const works = [
-            { id: "w1", title: "Tagged Popular", checkout_count: 7 },
+            { id: "w1", title: "Tagged Popular", checkout_count: 7, total_count: "1" },
         ];
         mockQuery.mockResolvedValue({ rows: works });
 
-        const result = await getPopularWorks("tag-uuid-1");
+        const result = await getPopularWorks(POP_PAGE, "tag-uuid-1");
 
-        expect(result).toEqual(works);
+        expect(result.total).toBe(1);
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("JOIN work_tags"),
-            ["tag-uuid-1"]
-        );
-        expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("wt.tag_id = $1"),
-            ["tag-uuid-1"]
+            ["tag-uuid-1", 25, 0]
         );
     });
 
-    it("returns empty array when no checkouts exist", async () => {
+    it("returns empty rows and zero total when no checkouts exist", async () => {
         mockQuery.mockResolvedValue({ rows: [] });
 
-        const result = await getPopularWorks();
+        const result = await getPopularWorks(POP_PAGE);
 
-        expect(result).toEqual([]);
+        expect(result).toEqual({ rows: [], total: 0 });
     });
 
     it("does not call requireStaffUser (public access)", async () => {
         mockGetCurrentUser.mockResolvedValue(null);
         mockQuery.mockResolvedValue({ rows: [] });
 
-        // Should NOT throw even though there's no authenticated user
-        await expect(getPopularWorks()).resolves.toEqual([]);
+        await expect(getPopularWorks(POP_PAGE)).resolves.toEqual({
+            rows: [],
+            total: 0,
+        });
     });
 });
 

--- a/src/__tests__/lib/data/checkouts.test.ts
+++ b/src/__tests__/lib/data/checkouts.test.ts
@@ -547,7 +547,7 @@ describe("getPopularWorks", () => {
         ];
         mockQuery.mockResolvedValue({ rows: works });
 
-        const result = await getPopularWorks(POP_PAGE, "tag-uuid-1");
+        const result = await getPopularWorks(POP_PAGE, { tagId: "tag-uuid-1" });
 
         expect(result.total).toBe(1);
         expect(mockQuery).toHaveBeenCalledWith(

--- a/src/__tests__/lib/data/users.test.ts
+++ b/src/__tests__/lib/data/users.test.ts
@@ -164,34 +164,39 @@ describe("getAllUsers", () => {
 
 // ─── getAdminAllUsers (admin) ───────────────────────────────────────
 
+const ADMIN_PAGE = { page: 1, pageSize: 20, offset: 0 };
+
 describe("getAdminAllUsers", () => {
     it("throws Unauthorized when not authenticated", async () => {
         mockGetCurrentUser.mockResolvedValue(null);
-        await expect(getAdminAllUsers()).rejects.toThrow("Unauthorized");
+        await expect(getAdminAllUsers(ADMIN_PAGE)).rejects.toThrow("Unauthorized");
     });
 
     it("throws Forbidden when role is staff", async () => {
         mockGetCurrentUser.mockResolvedValue(staffUser);
-        await expect(getAdminAllUsers()).rejects.toThrow("Forbidden");
+        await expect(getAdminAllUsers(ADMIN_PAGE)).rejects.toThrow("Forbidden");
     });
 
     it("throws Forbidden when role is user", async () => {
         mockGetCurrentUser.mockResolvedValue(regularUser);
-        await expect(getAdminAllUsers()).rejects.toThrow("Forbidden");
+        await expect(getAdminAllUsers(ADMIN_PAGE)).rejects.toThrow("Forbidden");
     });
 
-    it("returns all users with full fields for admin", async () => {
+    it("returns paginated users with total for admin", async () => {
         const users = [
-            { id: "u1", email: "a@b.com", name: "A", role: "admin" },
+            { id: "u1", email: "a@b.com", name: "A", role: "admin", total_count: "1" },
         ];
         mockQuery.mockResolvedValue({ rows: users });
 
-        const result = await getAdminAllUsers();
+        const result = await getAdminAllUsers(ADMIN_PAGE);
 
-        expect(result).toEqual(users);
+        expect(result).toEqual({
+            rows: [{ id: "u1", email: "a@b.com", name: "A", role: "admin" }],
+            total: 1,
+        });
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("SELECT id, email, name, role"),
-            undefined
+            expect.stringContaining("LIMIT $1 OFFSET $2"),
+            [20, 0]
         );
     });
 });

--- a/src/__tests__/lib/data/works.test.ts
+++ b/src/__tests__/lib/data/works.test.ts
@@ -54,62 +54,67 @@ beforeEach(() => {
 
 // ─── Authorization (shared across all staff-only functions) ─────────
 
+const PAGE = { page: 1, pageSize: 20, offset: 0 };
+
 describe("requireStaffUser (via getAllWorks)", () => {
     it("throws Unauthorized when not authenticated", async () => {
         mockGetCurrentUser.mockResolvedValue(null);
-        await expect(getAllWorks()).rejects.toThrow("Unauthorized");
+        await expect(getAllWorks(PAGE)).rejects.toThrow("Unauthorized");
     });
 
     it("throws Forbidden when role is user", async () => {
         mockGetCurrentUser.mockResolvedValue(regularUser);
-        await expect(getAllWorks()).rejects.toThrow("Forbidden");
+        await expect(getAllWorks(PAGE)).rejects.toThrow("Forbidden");
     });
 
     it("allows staff users", async () => {
         mockQuery.mockResolvedValue({ rows: [] });
-        await expect(getAllWorks()).resolves.toEqual([]);
+        await expect(getAllWorks(PAGE)).resolves.toEqual({ rows: [], total: 0 });
     });
 
     it("allows admin users", async () => {
         mockGetCurrentUser.mockResolvedValue(adminUser);
         mockQuery.mockResolvedValue({ rows: [] });
-        await expect(getAllWorks()).resolves.toEqual([]);
+        await expect(getAllWorks(PAGE)).resolves.toEqual({ rows: [], total: 0 });
     });
 });
 
 // ─── getAllWorks ─────────────────────────────────────────────────────
 
 describe("getAllWorks", () => {
-    it("returns all works from the database", async () => {
+    it("returns paginated works with total", async () => {
         const works = [
-            { id: "w1", title: "Book A" },
-            { id: "w2", title: "Book B" },
+            { id: "w1", title: "Book A", total_count: "2" },
+            { id: "w2", title: "Book B", total_count: "2" },
         ];
         mockQuery.mockImplementation((text: string) => {
             if (text.includes("FROM work_authors")) return Promise.resolve({ rows: [] });
             return Promise.resolve({ rows: works });
         });
 
-        const result = await getAllWorks();
+        const result = await getAllWorks(PAGE);
 
-        expect(result).toEqual([
-            { id: "w1", title: "Book A", authors: [] },
-            { id: "w2", title: "Book B", authors: [] },
-        ]);
+        expect(result).toEqual({
+            rows: [
+                { id: "w1", title: "Book A", authors: [] },
+                { id: "w2", title: "Book B", authors: [] },
+            ],
+            total: 2,
+        });
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("SELECT"),
-            undefined
+            expect.stringContaining("LIMIT $1 OFFSET $2"),
+            [20, 0]
         );
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("ORDER BY created_at DESC"),
-            undefined
+            expect.stringContaining("COUNT(*) OVER()"),
+            [20, 0]
         );
     });
 
-    it("returns an empty array when no works exist", async () => {
+    it("returns empty rows and zero total when no works exist", async () => {
         mockQuery.mockResolvedValue({ rows: [] });
-        const result = await getAllWorks();
-        expect(result).toEqual([]);
+        const result = await getAllWorks(PAGE);
+        expect(result).toEqual({ rows: [], total: 0 });
     });
 });
 
@@ -184,92 +189,103 @@ describe("getPublicWorkById", () => {
 
 // ─── searchWorks ────────────────────────────────────────────────────
 
+const SEARCH_PAGE = { page: 1, pageSize: 25, offset: 0 };
+
 describe("searchWorks", () => {
     it("searches without any filters", async () => {
-        const works = [{ id: "w1", title: "Book A" }];
+        const works = [{ id: "w1", title: "Book A", total_count: "1" }];
         mockQuery.mockImplementation((text: string) => {
             if (text.includes("FROM work_authors")) return Promise.resolve({ rows: [] });
             return Promise.resolve({ rows: works });
         });
 
-        const result = await searchWorks({});
+        const result = await searchWorks({}, SEARCH_PAGE);
 
-        expect(result).toEqual([{ id: "w1", title: "Book A", authors: [] }]);
+        expect(result.rows).toEqual([{ id: "w1", title: "Book A", authors: [] }]);
+        expect(result.total).toBe(1);
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("ORDER BY w.title ASC"),
-            undefined
-        );
-        // The main search query (params === undefined) should NOT have a WHERE clause
-        expect(mockQuery).toHaveBeenCalledWith(
-            expect.not.stringContaining("WHERE"),
-            undefined
+            [25, 0]
         );
     });
 
     it("searches with a text query", async () => {
         mockQuery.mockResolvedValue({ rows: [] });
 
-        await searchWorks({ q: "test" });
+        await searchWorks({ q: "test" }, SEARCH_PAGE);
 
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("ILIKE"),
-            ["%test%"]
+            ["%test%", 25, 0]
         );
     });
 
     it("searches with a media type filter", async () => {
         mockQuery.mockResolvedValue({ rows: [] });
 
-        await searchWorks({ mediaType: "book" });
+        await searchWorks({ mediaType: "book" }, SEARCH_PAGE);
 
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("w.media_type = $1"),
-            ["book"]
+            ["book", 25, 0]
         );
     });
 
     it("searches with both query and media type", async () => {
         mockQuery.mockResolvedValue({ rows: [] });
 
-        await searchWorks({ q: "test", mediaType: "ebook" });
+        await searchWorks({ q: "test", mediaType: "ebook" }, SEARCH_PAGE);
 
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("ILIKE"),
-            ["%test%", "ebook"]
-        );
-        expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("w.media_type = $2"),
-            ["%test%", "ebook"]
+            ["%test%", "ebook", 25, 0]
         );
     });
 
     it("searches with a tag filter", async () => {
         mockQuery.mockResolvedValue({ rows: [] });
 
-        await searchWorks({ tagId: "tag-1" });
+        await searchWorks({ tagId: "tag-1" }, SEARCH_PAGE);
 
         expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("JOIN work_tags"),
-            ["tag-1"]
-        );
-        expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("wt.tag_id = $1"),
-            ["tag-1"]
+            ["tag-1", 25, 0]
         );
     });
 
     it("searches with query, media type, and tag combined", async () => {
         mockQuery.mockResolvedValue({ rows: [] });
 
-        await searchWorks({ q: "test", mediaType: "book", tagId: "tag-1" });
+        await searchWorks(
+            { q: "test", mediaType: "book", tagId: "tag-1" },
+            SEARCH_PAGE
+        );
 
         expect(mockQuery).toHaveBeenCalledWith(
-            expect.stringContaining("JOIN work_tags"),
-            ["%test%", "book", "tag-1"]
-        );
-        expect(mockQuery).toHaveBeenCalledWith(
             expect.stringContaining("wt.tag_id = $3"),
-            ["%test%", "book", "tag-1"]
+            ["%test%", "book", "tag-1", 25, 0]
+        );
+    });
+
+    it("applies language filter", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        await searchWorks({ language: "French" }, SEARCH_PAGE);
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("w.language = $1"),
+            ["French", 25, 0]
+        );
+    });
+
+    it("applies sort direction to ORDER BY", async () => {
+        mockQuery.mockResolvedValue({ rows: [] });
+
+        await searchWorks({ sort: "date_published", dir: "desc" }, SEARCH_PAGE);
+
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining("ORDER BY w.date_published DESC"),
+            [25, 0]
         );
     });
 
@@ -277,8 +293,11 @@ describe("searchWorks", () => {
         mockGetCurrentUser.mockResolvedValue(null);
         mockQuery.mockResolvedValue({ rows: [] });
 
-        // Should NOT throw
-        await expect(searchWorks({})).resolves.toEqual([]);
+        await expect(searchWorks({}, SEARCH_PAGE)).resolves.toEqual({
+            rows: [],
+            total: 0,
+            languages: [],
+        });
     });
 });
 

--- a/src/__tests__/lib/pagination.test.ts
+++ b/src/__tests__/lib/pagination.test.ts
@@ -1,0 +1,71 @@
+import {
+    parsePageParams,
+    buildPaginatedResponse,
+    MAX_PAGE_SIZE,
+} from "@/lib/pagination";
+
+describe("parsePageParams", () => {
+    const sp = (q: string) => new URLSearchParams(q);
+
+    it("defaults to page 1 with default pageSize when no params", () => {
+        expect(parsePageParams(sp(""))).toEqual({
+            page: 1,
+            pageSize: 20,
+            offset: 0,
+        });
+    });
+
+    it("uses provided default pageSize", () => {
+        expect(parsePageParams(sp(""), 25)).toEqual({
+            page: 1,
+            pageSize: 25,
+            offset: 0,
+        });
+    });
+
+    it("parses valid page and pageSize", () => {
+        expect(parsePageParams(sp("page=3&pageSize=10"))).toEqual({
+            page: 3,
+            pageSize: 10,
+            offset: 20,
+        });
+    });
+
+    it("falls back to page 1 when page is zero, negative, or NaN", () => {
+        expect(parsePageParams(sp("page=0")).page).toBe(1);
+        expect(parsePageParams(sp("page=-5")).page).toBe(1);
+        expect(parsePageParams(sp("page=abc")).page).toBe(1);
+    });
+
+    it("floors fractional page values", () => {
+        expect(parsePageParams(sp("page=2.9")).page).toBe(2);
+    });
+
+    it("caps pageSize at MAX_PAGE_SIZE", () => {
+        expect(parsePageParams(sp(`pageSize=9999`)).pageSize).toBe(
+            MAX_PAGE_SIZE
+        );
+    });
+
+    it("falls back to default pageSize on invalid values", () => {
+        expect(parsePageParams(sp("pageSize=0")).pageSize).toBe(20);
+        expect(parsePageParams(sp("pageSize=abc")).pageSize).toBe(20);
+        expect(parsePageParams(sp("pageSize=-10")).pageSize).toBe(20);
+    });
+
+    it("computes offset from page and pageSize", () => {
+        expect(parsePageParams(sp("page=4&pageSize=25")).offset).toBe(75);
+    });
+});
+
+describe("buildPaginatedResponse", () => {
+    it("wraps items with total, page, pageSize", () => {
+        const params = { page: 2, pageSize: 10, offset: 10 };
+        expect(buildPaginatedResponse([{ id: 1 }, { id: 2 }], 42, params)).toEqual({
+            items: [{ id: 1 }, { id: 2 }],
+            total: 42,
+            page: 2,
+            pageSize: 10,
+        });
+    });
+});

--- a/src/app/admin/admin-users-client.tsx
+++ b/src/app/admin/admin-users-client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { PaginationControls } from "@/components/pagination-controls";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -43,8 +44,11 @@ interface User {
 
 interface AdminUsersClientProps {
   initialUsers: User[];
+  initialTotal: number;
   currentUserId: string;
 }
+
+const PAGE_SIZE = 20;
 
 const roleBadgeVariant: Record<string, "default" | "secondary" | "outline"> = {
   admin: "default",
@@ -54,10 +58,13 @@ const roleBadgeVariant: Record<string, "default" | "secondary" | "outline"> = {
 
 export function AdminUsersClient({
   initialUsers,
+  initialTotal,
   currentUserId,
 }: AdminUsersClientProps) {
   const router = useRouter();
   const [users, setUsers] = useState<User[]>(initialUsers);
+  const [total, setTotal] = useState(initialTotal);
+  const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState("all");
   const [formOpen, setFormOpen] = useState(false);
@@ -73,6 +80,19 @@ export function AdminUsersClient({
     password: "",
     role: "user",
   });
+
+  const refetch = useCallback(async (targetPage: number) => {
+    const res = await fetch(`/api/admin/users?page=${targetPage}&pageSize=${PAGE_SIZE}`);
+    if (!res.ok) return;
+    const data = await res.json();
+    setUsers(data.items);
+    setTotal(data.total);
+  }, []);
+
+  useEffect(() => {
+    if (page === 1) return; // initial data already hydrated
+    refetch(page);
+  }, [page, refetch]);
 
   const filteredUsers = useMemo(() => {
     return users.filter((user) => {
@@ -159,8 +179,12 @@ export function AdminUsersClient({
         }
 
         const created = await res.json();
-        setUsers((prev) => [created, ...prev]);
         toast.success(`User "${created.name}" created`);
+        if (page === 1) {
+          await refetch(1);
+        } else {
+          setPage(1);
+        }
       }
 
       setFormOpen(false);
@@ -186,9 +210,9 @@ export function AdminUsersClient({
       }
 
       const deletedName = deletingUser.name;
-      setUsers((prev) => prev.filter((u) => u.id !== deletingUser.id));
       setDeleteOpen(false);
       toast.success(`User "${deletedName}" deleted`);
+      await refetch(page);
       router.refresh();
     } finally {
       setSubmitting(false);
@@ -275,6 +299,13 @@ export function AdminUsersClient({
           )}
         </TableBody>
       </Table>
+
+      <PaginationControls
+        page={page}
+        pageSize={PAGE_SIZE}
+        total={total}
+        onPageChange={setPage}
+      />
 
       <Dialog open={formOpen} onOpenChange={setFormOpen}>
         <DialogContent>

--- a/src/app/admin/admin-users-client.tsx
+++ b/src/app/admin/admin-users-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { PaginationControls } from "@/components/pagination-controls";
 import { toast } from "sonner";
@@ -89,8 +89,12 @@ export function AdminUsersClient({
     setTotal(data.total);
   }, []);
 
+  const hydratedRef = useRef(true);
   useEffect(() => {
-    if (page === 1) return; // initial data already hydrated
+    if (hydratedRef.current) {
+      hydratedRef.current = false;
+      return;
+    }
     refetch(page);
   }, [page, refetch]);
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,13 +10,14 @@ export default async function AdminPage() {
     redirect("/");
   }
 
-  const users = await getAdminAllUsers();
+  const { rows, total } = await getAdminAllUsers({ page: 1, pageSize: 20, offset: 0 });
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold">User Management</h1>
       <AdminUsersClient
-        initialUsers={users}
+        initialUsers={rows}
+        initialTotal={total}
         currentUserId={user.id}
       />
     </div>

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminAllUsers, createUser } from "@/lib/data/users";
+import { parsePageParams, buildPaginatedResponse } from "@/lib/pagination";
 
 function mapErrorToResponse(error: unknown): NextResponse {
   const message =
@@ -19,10 +20,12 @@ function mapErrorToResponse(error: unknown): NextResponse {
   return NextResponse.json({ error: message }, { status: 500 });
 }
   
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const users = await getAdminAllUsers();
-    return NextResponse.json(users);
+    const { searchParams } = new URL(request.url);
+    const params = parsePageParams(searchParams, 20);
+    const { rows, total } = await getAdminAllUsers(params);
+    return NextResponse.json(buildPaginatedResponse(rows, total, params));
   } catch (error) {
     return mapErrorToResponse(error);
   }

--- a/src/app/api/search/popular/route.ts
+++ b/src/app/api/search/popular/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getPopularWorks } from "@/lib/data/checkouts";
 import { getTagsForWorks } from "@/lib/data/tags";
+import { parsePageParams, buildPaginatedResponse } from "@/lib/pagination";
 
 export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const tagId = searchParams.get("tag")?.trim() || "";
+    const pagination = parsePageParams(searchParams, 25);
 
-    const works = await getPopularWorks(tagId || undefined);
+    const { rows: works, total } = await getPopularWorks(
+        pagination,
+        tagId || undefined
+    );
 
     const workIds = works.map((w) => w.id);
     const tagsMap = await getTagsForWorks(workIds);
@@ -16,5 +21,7 @@ export async function GET(request: NextRequest) {
         tags: tagsMap[w.id] || [],
     }));
 
-    return NextResponse.json(worksWithTags);
+    return NextResponse.json(
+        buildPaginatedResponse(worksWithTags, total, pagination)
+    );
 }

--- a/src/app/api/search/popular/route.ts
+++ b/src/app/api/search/popular/route.ts
@@ -6,12 +6,17 @@ import { parsePageParams, buildPaginatedResponse } from "@/lib/pagination";
 export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const tagId = searchParams.get("tag")?.trim() || "";
+    const q = searchParams.get("q")?.trim() || "";
+    const mediaType = searchParams.get("media_type")?.trim() || "";
+    const language = searchParams.get("lang")?.trim() || "";
     const pagination = parsePageParams(searchParams, 25);
 
-    const { rows: works, total } = await getPopularWorks(
-        pagination,
-        tagId || undefined
-    );
+    const { rows: works, total } = await getPopularWorks(pagination, {
+        tagId: tagId || undefined,
+        q: q || undefined,
+        mediaType: mediaType || undefined,
+        language: language || undefined,
+    });
 
     const workIds = works.map((w) => w.id);
     const tagsMap = await getTagsForWorks(workIds);

--- a/src/app/api/search/works/route.ts
+++ b/src/app/api/search/works/route.ts
@@ -1,19 +1,43 @@
 import { NextRequest, NextResponse } from "next/server";
-import { searchWorks } from "@/lib/data/works";
+import { searchWorks, type SearchSortField } from "@/lib/data/works";
 import { getTagsForWorks } from "@/lib/data/tags";
 import { getWorkRatingSummaries } from "@/lib/data/ratings";
+import { parsePageParams } from "@/lib/pagination";
+
+const ALLOWED_SORTS: SearchSortField[] = [
+    "title",
+    "call_number",
+    "date_published",
+    "media_type",
+    "number_of_pages",
+];
 
 export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const q = searchParams.get("q")?.trim() || "";
     const mediaType = searchParams.get("media_type")?.trim() || "";
     const tagId = searchParams.get("tag")?.trim() || "";
+    const language = searchParams.get("lang")?.trim() || "";
+    const rawSort = searchParams.get("sort")?.trim() || "";
+    const rawDir = searchParams.get("dir")?.trim() || "";
+    const sort = (ALLOWED_SORTS as string[]).includes(rawSort)
+        ? (rawSort as SearchSortField)
+        : "title";
+    const dir = rawDir === "desc" ? "desc" : "asc";
 
-    const works = await searchWorks({
-        q: q || undefined,
-        mediaType: mediaType || undefined,
-        tagId: tagId || undefined,
-    });
+    const pagination = parsePageParams(searchParams, 25);
+
+    const { rows: works, total, languages } = await searchWorks(
+        {
+            q: q || undefined,
+            mediaType: mediaType || undefined,
+            tagId: tagId || undefined,
+            language: language || undefined,
+            sort,
+            dir,
+        },
+        pagination
+    );
 
     const workIds = works.map((w) => w.id);
     const [tagsMap, ratingsMap] = await Promise.all([
@@ -21,12 +45,18 @@ export async function GET(request: NextRequest) {
         getWorkRatingSummaries(workIds),
     ]);
 
-    const worksWithExtras = works.map((w) => ({
+    const items = works.map((w) => ({
         ...w,
         tags: tagsMap[w.id] || [],
         average_rating: ratingsMap[w.id]?.average_rating ?? null,
         rating_count: ratingsMap[w.id]?.rating_count ?? 0,
     }));
 
-    return NextResponse.json(worksWithExtras);
+    return NextResponse.json({
+        items,
+        total,
+        page: pagination.page,
+        pageSize: pagination.pageSize,
+        languages,
+    });
 }

--- a/src/app/api/staff/checkouts/route.ts
+++ b/src/app/api/staff/checkouts/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAllCheckouts, createCheckout } from "@/lib/data/checkouts";
+import { parsePageParams, buildPaginatedResponse } from "@/lib/pagination";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
     try {
-        const checkouts = await getAllCheckouts();
-        return NextResponse.json(checkouts);
+        const { searchParams } = new URL(request.url);
+        const params = parsePageParams(searchParams, 20);
+        const { rows, total } = await getAllCheckouts(params);
+        return NextResponse.json(buildPaginatedResponse(rows, total, params));
     } catch (error) {
         const message =
             error instanceof Error ? error.message : "Internal server error";

--- a/src/app/api/staff/works/export/route.ts
+++ b/src/app/api/staff/works/export/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import ExcelJS from "exceljs";
 import { requireStaff } from "@/lib/staff";
-import { getAllWorks } from "@/lib/data/works";
+import { getAllWorksForExport } from "@/lib/data/works";
 
 const HEADERS = [
     "Title",
@@ -24,7 +24,7 @@ export async function GET() {
     if (!check.authorized) return check.response;
 
     try {
-        const works = await getAllWorks();
+        const works = await getAllWorksForExport();
 
         const rows = works.map((w) => ({
             "Title": w.title,

--- a/src/app/api/staff/works/route.ts
+++ b/src/app/api/staff/works/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAllWorks, createWork } from "@/lib/data/works";
+import { parsePageParams, buildPaginatedResponse } from "@/lib/pagination";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
     try {
-        const works = await getAllWorks();
-        return NextResponse.json(works);
+        const { searchParams } = new URL(request.url);
+        const params = parsePageParams(searchParams, 20);
+        const { rows, total } = await getAllWorks(params);
+        return NextResponse.json(buildPaginatedResponse(rows, total, params));
     } catch (error) {
         const message =
             error instanceof Error ? error.message : "Internal server error";

--- a/src/app/search/search-client.tsx
+++ b/src/app/search/search-client.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { PaginationControls } from "@/components/pagination-controls";
 import {
     Select,
     SelectContent,
@@ -97,26 +98,7 @@ function extractYear(date: string): string {
     return match ? match[1] : date;
 }
 
-function compareValues(
-    a: string | number | null | undefined,
-    b: string | number | null | undefined,
-    direction: SortDirection
-): number {
-    // Nulls always go to the end
-    if (a == null && b == null) return 0;
-    if (a == null) return 1;
-    if (b == null) return -1;
-
-    let result: number;
-    if (typeof a === "number" && typeof b === "number") {
-        result = a - b;
-    } else {
-        result = String(a).localeCompare(String(b), undefined, {
-            sensitivity: "base",
-        });
-    }
-    return direction === "asc" ? result : -result;
-}
+const PAGE_SIZE = 25;
 
 interface Tag {
     id: string;
@@ -129,6 +111,9 @@ export function SearchClient({ initialQuery = "" }: { initialQuery?: string }) {
     const [mediaFilter, setMediaFilter] = useState("all");
     const [tagFilter, setTagFilter] = useState("all");
     const [results, setResults] = useState<Work[]>([]);
+    const [total, setTotal] = useState(0);
+    const [page, setPage] = useState(1);
+    const [availableLanguages, setAvailableLanguages] = useState<string[]>([]);
     const [loading, setLoading] = useState(false);
     const [hasSearched, setHasSearched] = useState(false);
     const [availableTags, setAvailableTags] = useState<Tag[]>([]);
@@ -149,40 +134,43 @@ export function SearchClient({ initialQuery = "" }: { initialQuery?: string }) {
             .catch(() => {});
     }, []);
 
-    const fetchResults = useCallback(async (q: string, media: string, tag: string, sort: SortField) => {
+    const fetchResults = useCallback(async (
+        q: string,
+        media: string,
+        tag: string,
+        lang: string,
+        sort: SortField,
+        dir: SortDirection,
+        targetPage: number
+    ) => {
         setLoading(true);
         try {
+            const params = new URLSearchParams();
+            params.set("page", String(targetPage));
+            params.set("pageSize", String(PAGE_SIZE));
+            if (q.trim()) params.set("q", q.trim());
+            if (media && media !== "all") params.set("media_type", media);
+            if (tag && tag !== "all") params.set("tag", tag);
+            if (lang && lang !== "all") params.set("lang", lang);
             if (sort === "popularity") {
-                const params = new URLSearchParams();
-                if (tag && tag !== "all") params.set("tag", tag);
-
                 const res = await fetch(`/api/search/popular?${params.toString()}`);
                 if (res.ok) {
-                    let data = await res.json();
-                    // Apply client-side text and media filters
-                    if (q.trim()) {
-                        const lowerQ = q.trim().toLowerCase();
-                        data = data.filter((w: Work) =>
-                            w.title.toLowerCase().includes(lowerQ) ||
-                            (w.publisher && w.publisher.toLowerCase().includes(lowerQ)) ||
-                            (w.authors ?? []).some((a) => a.name.toLowerCase().includes(lowerQ))
-                        );
-                    }
-                    if (media && media !== "all") {
-                        data = data.filter((w: Work) => w.media_type === media);
-                    }
-                    setResults(data);
+                    const data = await res.json();
+                    setResults(data.items);
+                    setTotal(data.total);
+                    // Popular endpoint has no languages — keep previous list
                 }
             } else {
-                const params = new URLSearchParams();
-                if (q.trim()) params.set("q", q.trim());
-                if (media && media !== "all") params.set("media_type", media);
-                if (tag && tag !== "all") params.set("tag", tag);
-
+                params.set("sort", sort);
+                params.set("dir", dir);
                 const res = await fetch(`/api/search/works?${params.toString()}`);
                 if (res.ok) {
                     const data = await res.json();
-                    setResults(data);
+                    setResults(data.items);
+                    setTotal(data.total);
+                    if (Array.isArray(data.languages)) {
+                        setAvailableLanguages(data.languages);
+                    }
                 }
             }
         } finally {
@@ -191,22 +179,18 @@ export function SearchClient({ initialQuery = "" }: { initialQuery?: string }) {
         }
     }, []);
 
-    // Debounced search
+    // Reset to page 1 whenever filters/sort change
+    useEffect(() => {
+        setPage(1);
+    }, [query, mediaFilter, tagFilter, languageFilter, sortField, sortDirection]);
+
+    // Debounced fetch
     useEffect(() => {
         const timer = setTimeout(() => {
-            fetchResults(query, mediaFilter, tagFilter, sortField);
+            fetchResults(query, mediaFilter, tagFilter, languageFilter, sortField, sortDirection, page);
         }, 300);
         return () => clearTimeout(timer);
-    }, [query, mediaFilter, tagFilter, sortField, fetchResults]);
-
-    // Distinct languages for filter dropdown
-    const availableLanguages = useMemo(() => {
-        const langs = new Set<string>();
-        results.forEach((w) => {
-            if (w.language) langs.add(w.language);
-        });
-        return Array.from(langs).sort();
-    }, [results]);
+    }, [query, mediaFilter, tagFilter, languageFilter, sortField, sortDirection, page, fetchResults]);
 
     // Build return URL encoding current filter state (for "Back to Search" on work pages)
     const searchReturnUrl = useMemo(() => {
@@ -222,25 +206,7 @@ export function SearchClient({ initialQuery = "" }: { initialQuery?: string }) {
         return `/search${qs ? "?" + qs : ""}`;
     }, [query, mediaFilter, tagFilter, languageFilter, sortField, sortDirection, viewMode]);
 
-    // Client-side filtering + sorting
-    const processedResults = useMemo(() => {
-        let filtered = results;
-
-        if (languageFilter && languageFilter !== "all") {
-            filtered = filtered.filter((w) => w.language === languageFilter);
-        }
-
-        // When sorting by popularity, data is already sorted by checkout_count DESC from the API
-        if (sortField === "popularity") {
-            return filtered;
-        }
-
-        const sorted = [...filtered].sort((a, b) =>
-            compareValues(a[sortField], b[sortField], sortDirection)
-        );
-
-        return sorted;
-    }, [results, languageFilter, sortField, sortDirection]);
+    const processedResults = results;
 
     function handleColumnSort(field: SortField) {
         if (sortField === field) {
@@ -426,10 +392,7 @@ export function SearchClient({ initialQuery = "" }: { initialQuery?: string }) {
             {!loading && processedResults.length > 0 && (
                 <>
                     <p className="text-sm text-muted-foreground">
-                        {processedResults.length} result
-                        {processedResults.length !== 1 ? "s" : ""} found
-                        {languageFilter !== "all" &&
-                            ` (filtered from ${results.length})`}
+                        {total} result{total !== 1 ? "s" : ""} found
                     </p>
 
                     {/* ====== GRID VIEW ====== */}
@@ -691,6 +654,13 @@ export function SearchClient({ initialQuery = "" }: { initialQuery?: string }) {
                             </TableBody>
                         </Table>
                     )}
+
+                    <PaginationControls
+                        page={page}
+                        pageSize={PAGE_SIZE}
+                        total={total}
+                        onPageChange={setPage}
+                    />
                 </>
             )}
         </div>

--- a/src/app/staff/page.tsx
+++ b/src/app/staff/page.tsx
@@ -1,12 +1,14 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth";
-import { getAllWorks } from "@/lib/data/works";
+import { getAllWorks, getAllWorksForExport } from "@/lib/data/works";
 import { getAllCheckouts } from "@/lib/data/checkouts";
 import { getAllUsers } from "@/lib/data/users";
 import { getAllTags } from "@/lib/data/tags";
 import { StaffWorksClient } from "./staff-works-client";
 import { StaffCheckoutsClient } from "./staff-checkouts-client";
 import { StaffTagsClient } from "./staff-tags-client";
+
+const FIRST_PAGE = { page: 1, pageSize: 20, offset: 0 };
 
 export default async function StaffPage() {
     const user = await getCurrentUser();
@@ -15,9 +17,10 @@ export default async function StaffPage() {
         redirect("/");
     }
 
-    const [works, checkouts, users, tags] = await Promise.all([
-        getAllWorks(),
-        getAllCheckouts(),
+    const [worksPage, checkoutsPage, allWorks, users, tags] = await Promise.all([
+        getAllWorks(FIRST_PAGE),
+        getAllCheckouts(FIRST_PAGE),
+        getAllWorksForExport(),
         getAllUsers(),
         getAllTags(),
     ]);
@@ -26,13 +29,17 @@ export default async function StaffPage() {
         <div className="mx-auto max-w-7xl px-4 py-8 space-y-10">
             <section>
                 <h1 className="mb-6 text-2xl font-bold">Item Management</h1>
-                <StaffWorksClient initialWorks={works} />
+                <StaffWorksClient
+                    initialWorks={worksPage.rows}
+                    initialTotal={worksPage.total}
+                />
             </section>
             <section>
                 <h2 className="mb-6 text-2xl font-bold">Checkouts</h2>
                 <StaffCheckoutsClient
-                    initialCheckouts={checkouts}
-                    works={works}
+                    initialCheckouts={checkoutsPage.rows}
+                    initialTotal={checkoutsPage.total}
+                    works={allWorks}
                     users={users}
                 />
             </section>

--- a/src/app/staff/page.tsx
+++ b/src/app/staff/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth";
 import { getAllWorks, getAllWorksForExport } from "@/lib/data/works";
-import { getAllCheckouts } from "@/lib/data/checkouts";
+import { getAllCheckouts, getActiveCheckedOutWorkIds } from "@/lib/data/checkouts";
 import { getAllUsers } from "@/lib/data/users";
 import { getAllTags } from "@/lib/data/tags";
 import { StaffWorksClient } from "./staff-works-client";
@@ -17,10 +17,11 @@ export default async function StaffPage() {
         redirect("/");
     }
 
-    const [worksPage, checkoutsPage, allWorks, users, tags] = await Promise.all([
+    const [worksPage, checkoutsPage, allWorks, activeCheckedOutIds, users, tags] = await Promise.all([
         getAllWorks(FIRST_PAGE),
         getAllCheckouts(FIRST_PAGE),
         getAllWorksForExport(),
+        getActiveCheckedOutWorkIds(),
         getAllUsers(),
         getAllTags(),
     ]);
@@ -40,6 +41,7 @@ export default async function StaffPage() {
                     initialCheckouts={checkoutsPage.rows}
                     initialTotal={checkoutsPage.total}
                     works={allWorks}
+                    activeCheckedOutIds={activeCheckedOutIds}
                     users={users}
                 />
             </section>

--- a/src/app/staff/staff-checkouts-client.tsx
+++ b/src/app/staff/staff-checkouts-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { PaginationControls } from "@/components/pagination-controls";
 import { toast } from "sonner";
@@ -83,8 +83,12 @@ export function StaffCheckoutsClient({
     setTotal(data.total);
   }, []);
 
+  const hydratedRef = useRef(true);
   useEffect(() => {
-    if (page === 1) return;
+    if (hydratedRef.current) {
+      hydratedRef.current = false;
+      return;
+    }
     refetch(page);
   }, [page, refetch]);
   const [search, setSearch] = useState("");

--- a/src/app/staff/staff-checkouts-client.tsx
+++ b/src/app/staff/staff-checkouts-client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { PaginationControls } from "@/components/pagination-controls";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -52,9 +53,12 @@ interface User {
 
 interface StaffCheckoutsClientProps {
   initialCheckouts: Checkout[];
+  initialTotal: number;
   works: Work[];
   users: User[];
 }
+
+const PAGE_SIZE = 20;
 
 function isOverdue(checkout: Checkout) {
   return !checkout.returned_at && new Date(checkout.due_date) < new Date();
@@ -62,11 +66,27 @@ function isOverdue(checkout: Checkout) {
 
 export function StaffCheckoutsClient({
   initialCheckouts,
+  initialTotal,
   works,
   users,
 }: StaffCheckoutsClientProps) {
   const router = useRouter();
-  const checkouts = initialCheckouts;
+  const [checkouts, setCheckouts] = useState<Checkout[]>(initialCheckouts);
+  const [total, setTotal] = useState(initialTotal);
+  const [page, setPage] = useState(1);
+
+  const refetch = useCallback(async (targetPage: number) => {
+    const res = await fetch(`/api/staff/checkouts?page=${targetPage}&pageSize=${PAGE_SIZE}`);
+    if (!res.ok) return;
+    const data = await res.json();
+    setCheckouts(data.items);
+    setTotal(data.total);
+  }, []);
+
+  useEffect(() => {
+    if (page === 1) return;
+    refetch(page);
+  }, [page, refetch]);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("active");
   const [formOpen, setFormOpen] = useState(false);
@@ -83,6 +103,7 @@ export function StaffCheckoutsClient({
       const res = await fetch(`/api/staff/checkouts/${id}/extend/approve`, { method: 'POST' });
       if (res.ok) {
         toast.success("Extension approved");
+        await refetch(page);
         router.refresh();
       } else {
         const data = await res.json().catch(() => ({}));
@@ -103,6 +124,7 @@ export function StaffCheckoutsClient({
       throw new Error(data.error || "Failed to reject extension");
     }
     toast.success("Extension rejected");
+    await refetch(page);
     router.refresh();
   };
 
@@ -279,19 +301,36 @@ export function StaffCheckoutsClient({
         </TableBody>
       </Table>
 
+      <PaginationControls
+        page={page}
+        pageSize={PAGE_SIZE}
+        total={total}
+        onPageChange={setPage}
+      />
+
       <CheckoutFormDialog
         open={formOpen}
         onOpenChange={setFormOpen}
         availableWorks={availableWorks}
         users={users}
-        onCreated={() => router.refresh()}
+        onCreated={async () => {
+          if (page === 1) {
+            await refetch(1);
+          } else {
+            setPage(1);
+          }
+          router.refresh();
+        }}
       />
 
       <ReturnCheckoutDialog
         open={returnOpen}
         onOpenChange={setReturnOpen}
         checkout={returningCheckout}
-        onReturned={() => router.refresh()}
+        onReturned={async () => {
+          await refetch(page);
+          router.refresh();
+        }}
       />
 
       <ConfirmDialog

--- a/src/app/staff/staff-checkouts-client.tsx
+++ b/src/app/staff/staff-checkouts-client.tsx
@@ -55,6 +55,7 @@ interface StaffCheckoutsClientProps {
   initialCheckouts: Checkout[];
   initialTotal: number;
   works: Work[];
+  activeCheckedOutIds: string[];
   users: User[];
 }
 
@@ -68,6 +69,7 @@ export function StaffCheckoutsClient({
   initialCheckouts,
   initialTotal,
   works,
+  activeCheckedOutIds,
   users,
 }: StaffCheckoutsClientProps) {
   const router = useRouter();
@@ -132,13 +134,10 @@ export function StaffCheckoutsClient({
     router.refresh();
   };
 
-  const checkedOutWorkIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const c of checkouts) {
-      if (!c.returned_at) ids.add(c.work_id);
-    }
-    return ids;
-  }, [checkouts]);
+  const checkedOutWorkIds = useMemo(
+    () => new Set(activeCheckedOutIds),
+    [activeCheckedOutIds]
+  );
 
   const availableWorks = useMemo(
     () => works.filter((w) => !checkedOutWorkIds.has(w.id)),

--- a/src/app/staff/staff-works-client.tsx
+++ b/src/app/staff/staff-works-client.tsx
@@ -82,8 +82,12 @@ export function StaffWorksClient({ initialWorks, initialTotal }: StaffWorksClien
         setTotal(data.total);
     }, []);
 
+    const hydratedRef = useRef(true);
     useEffect(() => {
-        if (page === 1) return;
+        if (hydratedRef.current) {
+            hydratedRef.current = false;
+            return;
+        }
         refetch(page);
     }, [page, refetch]);
 

--- a/src/app/staff/staff-works-client.tsx
+++ b/src/app/staff/staff-works-client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useMemo, useRef } from "react";
+import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { PaginationControls } from "@/components/pagination-controls";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -52,13 +53,17 @@ interface Work {
 
 interface StaffWorksClientProps {
     initialWorks: Work[];
+    initialTotal: number;
 }
 
 const MEDIA_TYPES = ["book", "ebook", "audiobook", "periodical", "dvd", "other"];
+const PAGE_SIZE = 20;
 
-export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
+export function StaffWorksClient({ initialWorks, initialTotal }: StaffWorksClientProps) {
     const router = useRouter();
     const [works, setWorks] = useState<Work[]>(initialWorks);
+    const [total, setTotal] = useState(initialTotal);
+    const [page, setPage] = useState(1);
     const [search, setSearch] = useState("");
     const [mediaFilter, setMediaFilter] = useState("all");
     const [formOpen, setFormOpen] = useState(false);
@@ -68,6 +73,19 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
     const [importing, setImporting] = useState(false);
     const [dragging, setDragging] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const refetch = useCallback(async (targetPage: number) => {
+        const res = await fetch(`/api/staff/works?page=${targetPage}&pageSize=${PAGE_SIZE}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setWorks(data.items);
+        setTotal(data.total);
+    }, []);
+
+    useEffect(() => {
+        if (page === 1) return;
+        refetch(page);
+    }, [page, refetch]);
 
     const filteredWorks = useMemo(() => {
         return works.filter((work) => {
@@ -98,15 +116,19 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
 
     function handleSaved(work: Work, isNew: boolean) {
         if (isNew) {
-            setWorks((prev) => [work, ...prev]);
+            if (page === 1) {
+                refetch(1);
+            } else {
+                setPage(1);
+            }
         } else {
             setWorks((prev) => prev.map((w) => (w.id === work.id ? work : w)));
         }
         router.refresh();
     }
 
-    function handleDeleted(id: string) {
-        setWorks((prev) => prev.filter((w) => w.id !== id));
+    function handleDeleted(_id: string) {
+        refetch(page);
         router.refresh();
     }
 
@@ -137,10 +159,10 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
                     `${imported} imported, ${skipped.length} skipped (${rowList})`
                 );
             }
-            const worksRes = await fetch("/api/staff/works");
-            if (worksRes.ok) {
-                const updatedWorks = await worksRes.json();
-                setWorks(updatedWorks);
+            if (page === 1) {
+                await refetch(1);
+            } else {
+                setPage(1);
             }
         } catch {
             toast.error("Import failed");
@@ -316,6 +338,13 @@ export function StaffWorksClient({ initialWorks }: StaffWorksClientProps) {
                     )}
                 </TableBody>
             </Table>
+
+            <PaginationControls
+                page={page}
+                pageSize={PAGE_SIZE}
+                total={total}
+                onPageChange={setPage}
+            />
 
             <WorkFormDialog
                 open={formOpen}

--- a/src/components/pagination-controls.tsx
+++ b/src/components/pagination-controls.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface PaginationControlsProps {
+    page: number;
+    pageSize: number;
+    total: number;
+    onPageChange: (page: number) => void;
+}
+
+function getPageWindow(current: number, totalPages: number): (number | "...")[] {
+    const items: (number | "...")[] = [];
+    const add = (n: number | "...") => items.push(n);
+
+    if (totalPages <= 7) {
+        for (let i = 1; i <= totalPages; i++) add(i);
+        return items;
+    }
+
+    add(1);
+    if (current > 3) add("...");
+    const start = Math.max(2, current - 1);
+    const end = Math.min(totalPages - 1, current + 1);
+    for (let i = start; i <= end; i++) add(i);
+    if (current < totalPages - 2) add("...");
+    add(totalPages);
+    return items;
+}
+
+export function PaginationControls({
+    page,
+    pageSize,
+    total,
+    onPageChange,
+}: PaginationControlsProps) {
+    const totalPages = Math.max(1, Math.ceil(total / pageSize));
+    if (total === 0 || totalPages <= 1) return null;
+
+    const window = getPageWindow(page, totalPages);
+
+    return (
+        <nav
+            aria-label="Pagination"
+            className="flex items-center justify-center gap-1 py-4"
+        >
+            <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(page - 1)}
+                disabled={page <= 1}
+                aria-label="Previous page"
+            >
+                <ChevronLeft /> Previous
+            </Button>
+            {window.map((item, i) =>
+                item === "..." ? (
+                    <span
+                        key={`ellipsis-${i}`}
+                        className="px-2 text-sm text-muted-foreground"
+                        aria-hidden="true"
+                    >
+                        …
+                    </span>
+                ) : (
+                    <Button
+                        key={item}
+                        variant={item === page ? "default" : "outline"}
+                        size="sm"
+                        onClick={() => onPageChange(item)}
+                        aria-current={item === page ? "page" : undefined}
+                    >
+                        {item}
+                    </Button>
+                )
+            )}
+            <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(page + 1)}
+                disabled={page >= totalPages}
+                aria-label="Next page"
+            >
+                Next <ChevronRight />
+            </Button>
+        </nav>
+    );
+}

--- a/src/lib/data/checkouts.ts
+++ b/src/lib/data/checkouts.ts
@@ -182,6 +182,15 @@ export async function isWorkCheckedOut(workId: string): Promise<boolean> {
     return activeCheckout.rows.length > 0;
 }
 
+/** Get all currently-checked-out (not returned) work IDs. Staff only. */
+export async function getActiveCheckedOutWorkIds(): Promise<string[]> {
+    await requireStaffUser();
+    const result = await query(
+        "SELECT DISTINCT work_id FROM checkouts WHERE returned_at IS NULL"
+    );
+    return result.rows.map((r: { work_id: string }) => String(r.work_id));
+}
+
 /** Get the active (not returned) checkout ID for a specific work, if any. Return null if none. */
 export async function getActiveCheckoutForWork(
     workId: string
@@ -403,17 +412,51 @@ export interface PopularWorkDTO {
  */
 export async function getPopularWorks(
     pagination: PaginationParams,
-    tagId?: string
+    filters: {
+        tagId?: string;
+        q?: string;
+        mediaType?: string;
+        language?: string;
+    } = {}
 ): Promise<{ rows: PopularWorkDTO[]; total: number }> {
     const conditions: string[] = [];
     const values: unknown[] = [];
     let paramIndex = 1;
 
     let tagJoin = "";
-    if (tagId) {
+    if (filters.tagId) {
         tagJoin = "JOIN work_tags wt ON wt.work_id = w.id";
         conditions.push(`wt.tag_id = $${paramIndex}`);
-        values.push(tagId);
+        values.push(filters.tagId);
+        paramIndex++;
+    }
+
+    if (filters.q) {
+        conditions.push(
+            `(w.title ILIKE $${paramIndex}
+              OR w.publisher ILIKE $${paramIndex}
+              OR w.isbn_10 ILIKE $${paramIndex}
+              OR w.isbn_13 ILIKE $${paramIndex}
+              OR w.lccn ILIKE $${paramIndex}
+              OR EXISTS (
+                SELECT 1 FROM work_authors wa
+                JOIN authors a ON a.id = wa.author_id
+                WHERE wa.work_id = w.id AND a.name ILIKE $${paramIndex}
+              ))`
+        );
+        values.push(`%${filters.q}%`);
+        paramIndex++;
+    }
+
+    if (filters.mediaType) {
+        conditions.push(`w.media_type = $${paramIndex}`);
+        values.push(filters.mediaType);
+        paramIndex++;
+    }
+
+    if (filters.language) {
+        conditions.push(`w.language = $${paramIndex}`);
+        values.push(filters.language);
         paramIndex++;
     }
 

--- a/src/lib/data/checkouts.ts
+++ b/src/lib/data/checkouts.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { query } from "@/lib/db";
 import { getCurrentUser } from "@/lib/auth";
+import type { PaginationParams } from "@/lib/pagination";
 
 // ---------------------------------------------------------------------------
 // Types / DTOs
@@ -66,22 +67,33 @@ async function requireStaffUser() {
 // Read operations
 // ---------------------------------------------------------------------------
 
-/** List all checkouts with joined work & user info (staff only). */
-export async function getAllCheckouts(): Promise<CheckoutDTO[]> {
+/** List all checkouts with joined work & user info (staff only), paginated. */
+export async function getAllCheckouts(
+    params: PaginationParams
+): Promise<{ rows: CheckoutDTO[]; total: number }> {
     await requireStaffUser();
 
     const result = await query(
         `SELECT c.id, c.work_id, c.user_id, c.checked_out_at, c.due_date,
                 c.returned_at, c.reminder_sent_at, c.extension_status, c.created_at, c.updated_at,
                 w.title AS work_title,
-                u.name AS user_name, u.email AS user_email
+                u.name AS user_name, u.email AS user_email,
+                COUNT(*) OVER() AS total_count
          FROM checkouts c
          JOIN works w ON w.id = c.work_id
          JOIN users u ON u.id = c.user_id
-         ORDER BY c.created_at DESC`
+         ORDER BY c.created_at DESC
+         LIMIT $1 OFFSET $2`,
+        [params.pageSize, params.offset]
     );
 
-    return result.rows as CheckoutDTO[];
+    const total = Number(result.rows[0]?.total_count ?? 0);
+    const rows = result.rows.map((r: Record<string, unknown>) => {
+        const { total_count: _ignored, ...rest } = r;
+        return rest;
+    }) as unknown as CheckoutDTO[];
+
+    return { rows, total };
 }
 
 /** Get a single checkout by ID with joined work & user info (staff only). */
@@ -389,7 +401,10 @@ export interface PopularWorkDTO {
  * Public — no auth required.
  * Optionally filter by tag (genre) when tagId is provided.
  */
-export async function getPopularWorks(tagId?: string): Promise<PopularWorkDTO[]> {
+export async function getPopularWorks(
+    pagination: PaginationParams,
+    tagId?: string
+): Promise<{ rows: PopularWorkDTO[]; total: number }> {
     const conditions: string[] = [];
     const values: unknown[] = [];
     let paramIndex = 1;
@@ -405,23 +420,32 @@ export async function getPopularWorks(tagId?: string): Promise<PopularWorkDTO[]>
     const whereClause =
         conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
+    const paginatedValues = [...values, pagination.pageSize, pagination.offset];
+
     const result = await query(
         `SELECT w.id, w.title, w.date_published, w.publisher,
                 w.lccn, w.isbn_10, w.isbn_13, w.media_type, w.number_of_pages,
                 w.language, w.location, w.call_number,
                 (w.cover IS NOT NULL) as has_cover,
                 w.updated_at,
-                COALESCE(COUNT(c.id), 0)::int AS checkout_count
+                COALESCE(COUNT(c.id), 0)::int AS checkout_count,
+                COUNT(*) OVER() AS total_count
          FROM works w
          LEFT JOIN checkouts c ON c.work_id = w.id
          ${tagJoin} ${whereClause}
          GROUP BY w.id
-         ORDER BY checkout_count DESC
-         LIMIT 50`,
-        values.length > 0 ? values : undefined
+         ORDER BY checkout_count DESC, w.id ASC
+         LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+        paginatedValues
     );
 
-    return result.rows as PopularWorkDTO[];
+    const total = Number(result.rows[0]?.total_count ?? 0);
+    const rows = result.rows.map((r: Record<string, unknown>) => {
+        const { total_count: _ignored, ...rest } = r;
+        return rest;
+    }) as unknown as PopularWorkDTO[];
+
+    return { rows, total };
 }
 
 /**

--- a/src/lib/data/users.ts
+++ b/src/lib/data/users.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { query } from "@/lib/db";
 import { getCurrentUser, hashPassword } from "@/lib/auth";
+import type { PaginationParams } from "@/lib/pagination";
 
 // ---------------------------------------------------------------------------
 // Types / DTOs
@@ -127,15 +128,28 @@ export async function getAllUsers(): Promise<UserListDTO[]> {
 // Read operations (admin)
 // ---------------------------------------------------------------------------
 
-/** List all users with full admin fields (admin only). */
-export async function getAdminAllUsers(): Promise<UserAdminDTO[]> {
+/** List all users with full admin fields (admin only), paginated. */
+export async function getAdminAllUsers(
+    params: PaginationParams
+): Promise<{ rows: UserAdminDTO[]; total: number }> {
     await requireAdminUser();
 
     const result = await query(
-        "SELECT id, email, name, role, created_at, updated_at FROM users ORDER BY created_at DESC"
+        `SELECT id, email, name, role, created_at, updated_at,
+                COUNT(*) OVER() AS total_count
+         FROM users
+         ORDER BY created_at DESC
+         LIMIT $1 OFFSET $2`,
+        [params.pageSize, params.offset]
     );
 
-    return result.rows as UserAdminDTO[];
+    const total = Number(result.rows[0]?.total_count ?? 0);
+    const rows = result.rows.map((r: Record<string, unknown>) => {
+        const { total_count: _ignored, ...rest } = r;
+        return rest;
+    }) as unknown as UserAdminDTO[];
+
+    return { rows, total };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/data/works.ts
+++ b/src/lib/data/works.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { query } from "@/lib/db";
 import { getCurrentUser } from "@/lib/auth";
+import type { PaginationParams } from "@/lib/pagination";
 
 // ---------------------------------------------------------------------------
 // Types / DTOs
@@ -149,8 +150,36 @@ async function replaceContributors(
 // Read operations
 // ---------------------------------------------------------------------------
 
-/** List all works (staff only). Returns DTOs without cover data. */
-export async function getAllWorks(): Promise<WorkDTO[]> {
+/** List all works (staff only), paginated. Returns DTOs without cover data. */
+export async function getAllWorks(
+    params: PaginationParams
+): Promise<{ rows: WorkDTO[]; total: number }> {
+    await requireStaffUser();
+
+    const result = await query(
+        `SELECT id, created_at, title, date_published, publisher,
+                lccn, isbn_10, isbn_13, media_type, number_of_pages, language,
+                location, call_number, updated_at,
+                COUNT(*) OVER() AS total_count
+         FROM works ORDER BY created_at DESC
+         LIMIT $1 OFFSET $2`,
+        [params.pageSize, params.offset]
+    );
+
+    const total = Number(result.rows[0]?.total_count ?? 0);
+    const rows = result.rows.map((r: Record<string, unknown>) => {
+        const { total_count: _ignored, ...rest } = r;
+        return rest;
+    }) as unknown as WorkDTO[];
+
+    return {
+        rows: (await attachAuthorsToWorks(rows)) as WorkDTO[],
+        total,
+    };
+}
+
+/** List all works without pagination (staff only). Used for bulk export. */
+export async function getAllWorksForExport(): Promise<WorkDTO[]> {
     await requireStaffUser();
 
     const result = await query(
@@ -197,17 +226,44 @@ export async function getPublicWorkById(id: string): Promise<WorkWithCoverDTO | 
     return withAuthors as WorkWithCoverDTO;
 }
 
-/** Search works (public). Returns DTOs without cover data. */
-export async function searchWorks(params: {
+export type SearchSortField =
+    | "title"
+    | "call_number"
+    | "date_published"
+    | "media_type"
+    | "number_of_pages";
+
+const SEARCH_SORT_COLUMNS: Record<SearchSortField, string> = {
+    title: "w.title",
+    call_number: "w.call_number",
+    date_published: "w.date_published",
+    media_type: "w.media_type",
+    number_of_pages: "w.number_of_pages",
+};
+
+export interface SearchWorksFilters {
     q?: string;
     mediaType?: string;
     tagId?: string;
-}): Promise<WorkDTO[]> {
+    language?: string;
+    sort?: SearchSortField;
+    dir?: "asc" | "desc";
+}
+
+/** Search works (public), paginated with optional sort + language filter. */
+export async function searchWorks(
+    filters: SearchWorksFilters,
+    pagination: PaginationParams
+): Promise<{
+    rows: (WorkDTO & { has_cover: boolean })[];
+    total: number;
+    languages: string[];
+}> {
     const conditions: string[] = [];
     const values: unknown[] = [];
     let paramIndex = 1;
 
-    if (params.q) {
+    if (filters.q) {
         conditions.push(
             `(w.title ILIKE $${paramIndex}
               OR w.publisher ILIKE $${paramIndex}
@@ -220,41 +276,80 @@ export async function searchWorks(params: {
                 WHERE wa.work_id = w.id AND a.name ILIKE $${paramIndex}
               ))`
         );
-        values.push(`%${params.q}%`);
+        values.push(`%${filters.q}%`);
         paramIndex++;
     }
 
-    if (params.mediaType) {
+    if (filters.mediaType) {
         conditions.push(`w.media_type = $${paramIndex}`);
-        values.push(params.mediaType);
+        values.push(filters.mediaType);
         paramIndex++;
     }
 
     let joinClause = "";
-    if (params.tagId) {
+    if (filters.tagId) {
         joinClause = `JOIN work_tags wt ON wt.work_id = w.id`;
         conditions.push(`wt.tag_id = $${paramIndex}`);
-        values.push(params.tagId);
+        values.push(filters.tagId);
+        paramIndex++;
+    }
+
+    // language filter applies to paginated query only (not to distinct-languages query)
+    const preLangConditions = [...conditions];
+    const preLangValues = [...values];
+
+    if (filters.language) {
+        conditions.push(`w.language = $${paramIndex}`);
+        values.push(filters.language);
         paramIndex++;
     }
 
     const whereClause =
         conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
+    const sortCol = SEARCH_SORT_COLUMNS[filters.sort ?? "title"] ?? "w.title";
+    const sortDir = filters.dir === "desc" ? "DESC" : "ASC";
+    const orderBy = `ORDER BY ${sortCol} ${sortDir} NULLS LAST, w.id ASC`;
+
+    const paginatedValues = [...values, pagination.pageSize, pagination.offset];
+
     const result = await query(
         `SELECT w.id, w.title, w.date_published, w.publisher,
                 w.lccn, w.isbn_10, w.isbn_13, w.media_type, w.number_of_pages,
                 w.language, w.location, w.call_number,
                 (w.cover IS NOT NULL) as has_cover,
-                updated_at
+                updated_at,
+                COUNT(*) OVER() AS total_count
          FROM works w ${joinClause} ${whereClause}
-         ORDER BY w.title ASC`,
-        values.length > 0 ? values : undefined
+         ${orderBy}
+         LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+        paginatedValues
     );
 
-    return (await attachAuthorsToWorks(
-        result.rows as (WorkDTO & { has_cover: boolean })[]
-    )) as (WorkDTO & { has_cover: boolean })[];
+    const total = Number(result.rows[0]?.total_count ?? 0);
+    const rawRows = result.rows.map((r: Record<string, unknown>) => {
+        const { total_count: _ignored, ...rest } = r;
+        return rest;
+    }) as unknown as (WorkDTO & { has_cover: boolean })[];
+
+    const rows = (await attachAuthorsToWorks(rawRows)) as (WorkDTO & {
+        has_cover: boolean;
+    })[];
+
+    // Distinct languages for the same filter set (ignoring language filter itself)
+    const preLangWhere =
+        preLangConditions.length > 0
+            ? `WHERE ${preLangConditions.join(" AND ")} AND w.language IS NOT NULL`
+            : `WHERE w.language IS NOT NULL`;
+    const langResult = await query(
+        `SELECT DISTINCT w.language
+         FROM works w ${joinClause} ${preLangWhere}
+         ORDER BY w.language ASC`,
+        preLangValues.length > 0 ? preLangValues : undefined
+    );
+    const languages = langResult.rows.map((r: { language: string }) => r.language);
+
+    return { rows, total, languages };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,43 @@
+export const MAX_PAGE_SIZE = 100;
+export const DEFAULT_PAGE_SIZE = 20;
+
+export interface PaginationParams {
+    page: number;
+    pageSize: number;
+    offset: number;
+}
+
+export interface PaginatedResponse<T> {
+    items: T[];
+    total: number;
+    page: number;
+    pageSize: number;
+}
+
+export function parsePageParams(
+    searchParams: URLSearchParams,
+    defaultPageSize: number = DEFAULT_PAGE_SIZE
+): PaginationParams {
+    const rawPage = Number(searchParams.get("page") ?? "1");
+    const rawSize = Number(searchParams.get("pageSize") ?? defaultPageSize);
+    const page =
+        Number.isFinite(rawPage) && rawPage >= 1 ? Math.floor(rawPage) : 1;
+    const pageSize =
+        Number.isFinite(rawSize) && rawSize >= 1
+            ? Math.min(Math.floor(rawSize), MAX_PAGE_SIZE)
+            : defaultPageSize;
+    return { page, pageSize, offset: (page - 1) * pageSize };
+}
+
+export function buildPaginatedResponse<T>(
+    items: T[],
+    total: number,
+    params: PaginationParams
+): PaginatedResponse<T> {
+    return {
+        items,
+        total,
+        page: params.page,
+        pageSize: params.pageSize,
+    };
+}


### PR DESCRIPTION
## Summary
- New `src/lib/pagination.ts` utility (`parsePageParams`, `buildPaginatedResponse`) + `PaginationControls` component.
- Server-side offset/limit pagination added to: `/api/staff/works`, `/api/staff/checkouts`, `/api/admin/users`, `/api/search/works`, `/api/search/popular`.
- Response shape changed to `{items, total, page, pageSize}` — breaking; all client consumers updated in this PR.
- Search sort/direction/language filter moved server-side (was page-local before, would have been incorrect after pagination).
- Search response includes distinct `languages` for filter dropdown.
- `getAllWorksForExport` preserved for unpaginated Excel export.
- 20 per page for admin/staff CRUD; 25 per page for search/popular (5×5 grid at `md`).

## Closes
#51

## Human QA steps
- [ ] Seed ≥40 works, ≥40 checkouts, ≥25 users.
- [ ] `/admin` — confirm 20 users per page, Prev disabled on page 1, Next paginates, total count matches `SELECT COUNT(*) FROM users`.
- [ ] `/staff` — works section paginates independently from checkouts section; deleting a work refetches current page.
- [ ] `/staff` — add a new work, confirm page jumps to 1 and new work appears.
- [ ] `/search` — 25 results visible (5×5 at laptop breakpoint); apply `media_type=book`, confirm page resets and total matches filter.
- [ ] `/search` — sort by Title asc across page boundary: last row of page 1 sorts before first row of page 2.
- [ ] `/search` — change Language filter to English; total updates; navigate to page 2; results still all English.
- [ ] `/search` — popularity sort: confirm 25 per page, navigate to page 2.
- [ ] Edge: navigate to `/api/staff/works?page=9999` — returns empty items with total preserved, no crash.
- [ ] Excel export from staff page still exports all works (not just current page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)